### PR TITLE
Enhance grid with totals and row editing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -10,6 +10,13 @@ h1 {
   font-weight: 600;
 }
 
+.add-button {
+  margin-bottom: 1rem;
+  padding: 0.25rem 0.5rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
 .grid {
   height: 400px;
   width: 100%;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,12 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { AgGridReact } from 'ag-grid-react'
-import type { ColDef } from 'ag-grid-community'
+import type { CellValueChangedEvent, ColDef } from 'ag-grid-community'
 import 'ag-grid-community/styles/ag-grid.css'
 import 'ag-grid-community/styles/ag-theme-alpine.css'
 import './App.css'
 
 function App() {
-  const [rowData] = useState([
+  const [rowData, setRowData] = useState([
     { account: 'Revenue', amount: 1000 },
     { account: 'Cost of Goods Sold', amount: -300 },
     { account: 'Operating Expenses', amount: -200 },
@@ -25,14 +25,43 @@ function App() {
     [],
   )
 
+  const total = useMemo(
+    () => rowData.reduce((sum, row) => sum + Number(row.amount), 0),
+    [rowData],
+  )
+
+  const pinnedBottomRowData = useMemo(
+    () => [{ account: 'Total', amount: total }],
+    [total],
+  )
+
+  const onCellValueChanged = useCallback(
+    (params: CellValueChangedEvent) => {
+      if (params.rowIndex == null) return
+      const data = [...rowData]
+      data[params.rowIndex] = params.data
+      setRowData(data)
+    },
+    [rowData],
+  )
+
+  const handleAddRow = useCallback(() => {
+    setRowData([...rowData, { account: '', amount: 0 }])
+  }, [rowData])
+
   return (
     <div className="container">
       <h1>Financial Model</h1>
+      <button type="button" onClick={handleAddRow} className="add-button">
+        Add Row
+      </button>
       <div className="ag-theme-alpine grid">
         <AgGridReact
           rowData={rowData}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}
+          pinnedBottomRowData={pinnedBottomRowData}
+          onCellValueChanged={onCellValueChanged}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extend financial model grid to allow editing rows
- add button to insert new rows
- compute and show totals in a pinned bottom row

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687cb152a3d88327a7fc3301b54142ac