### PR TITLE
Add core utility tests

### DIFF
--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -1,0 +1,36 @@
+from app.core.config import Settings
+from app.core.permissions import (
+    PermissionChecker,
+    Permission,
+    get_permission_description,
+)
+from app.models.role import RoleType
+
+
+def test_get_cors_origins_parsing():
+    settings = Settings(BACKEND_CORS_ORIGINS="http://a.com,http://b.com")
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+    star = Settings(BACKEND_CORS_ORIGINS="*")
+    assert star.get_cors_origins() == ["*"]
+
+
+def test_permission_checker_basic():
+    admin_roles = [RoleType.ADMIN.value]
+    viewer_roles = [RoleType.VIEWER.value]
+
+    assert PermissionChecker.has_permission(admin_roles, Permission.USER_CREATE)
+    assert not PermissionChecker.has_permission(viewer_roles, Permission.USER_CREATE)
+    assert PermissionChecker.has_any_permission(viewer_roles, [Permission.USER_READ, Permission.DATA_EXPORT])
+    assert PermissionChecker.has_all_permissions(admin_roles, [Permission.USER_READ, Permission.USER_DELETE])
+
+    perms = PermissionChecker.get_user_permissions(viewer_roles)
+    assert Permission.DATA_EXPORT in perms
+
+    assert PermissionChecker.can_access_resource(admin_roles, 1, 2, Permission.MODEL_READ)
+    assert PermissionChecker.can_access_resource(viewer_roles, 1, 1, Permission.MODEL_READ)
+    assert PermissionChecker.can_access_resource(viewer_roles, 2, 1, Permission.MODEL_READ)
+
+
+def test_get_permission_description():
+    desc = get_permission_description(Permission.USER_CREATE)
+    assert "Create" in desc

--- a/backend/tests/test_core_utils.py
+++ b/backend/tests/test_core_utils.py
@@ -1,0 +1,47 @@
+import time
+from datetime import timedelta
+import pytest
+from app.core.security import (
+    get_password_hash,
+    verify_password,
+    generate_secure_token,
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+    check_password_strength,
+)
+
+
+def test_password_hash_and_verify():
+    password = "StrongPassw0rd!"
+    hashed = get_password_hash(password)
+    assert hashed != password
+    assert verify_password(password, hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_generate_secure_token_uniqueness():
+    token1 = generate_secure_token(16)
+    token2 = generate_secure_token(16)
+    assert len(token1) == 16
+    assert token1 != token2
+
+
+def test_jwt_token_creation_and_verification():
+    token = create_access_token("user123", expires_delta=timedelta(minutes=5))
+    assert verify_token(token) == "user123"
+    refresh = create_refresh_token("user123")
+    assert verify_token(refresh, token_type="refresh") == "user123"
+
+
+def test_jwt_token_expiration():
+    expired = create_access_token("user123", expires_delta=timedelta(seconds=-1))
+    time.sleep(1)
+    assert verify_token(expired) is None
+
+
+def test_check_password_strength():
+    weak = check_password_strength("abc")
+    assert not weak["is_strong"]
+    strong = check_password_strength("VeryStr0ng!Pass")
+    assert strong["is_strong"]


### PR DESCRIPTION
## Summary
- add tests for security token utilities
- add tests for config origins and permissions utilities

## Testing
- `pytest -q` *(fails: Coverage failure: total of 35 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed7fb15c8327b833191ac164ac27