### PR TITLE
Add unit tests for models and file utilities

### DIFF
--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -1,0 +1,36 @@
+from app.core.config import Settings
+from app.core.permissions import (
+    PermissionChecker,
+    Permission,
+    get_permission_description,
+)
+from app.models.role import RoleType
+
+
+def test_get_cors_origins_parsing():
+    settings = Settings(BACKEND_CORS_ORIGINS="http://a.com,http://b.com")
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+    star = Settings(BACKEND_CORS_ORIGINS="*")
+    assert star.get_cors_origins() == ["*"]
+
+
+def test_permission_checker_basic():
+    admin_roles = [RoleType.ADMIN.value]
+    viewer_roles = [RoleType.VIEWER.value]
+
+    assert PermissionChecker.has_permission(admin_roles, Permission.USER_CREATE)
+    assert not PermissionChecker.has_permission(viewer_roles, Permission.USER_CREATE)
+    assert PermissionChecker.has_any_permission(viewer_roles, [Permission.USER_READ, Permission.DATA_EXPORT])
+    assert PermissionChecker.has_all_permissions(admin_roles, [Permission.USER_READ, Permission.USER_DELETE])
+
+    perms = PermissionChecker.get_user_permissions(viewer_roles)
+    assert Permission.DATA_EXPORT in perms
+
+    assert PermissionChecker.can_access_resource(admin_roles, 1, 2, Permission.MODEL_READ)
+    assert PermissionChecker.can_access_resource(viewer_roles, 1, 1, Permission.MODEL_READ)
+    assert PermissionChecker.can_access_resource(viewer_roles, 2, 1, Permission.MODEL_READ)
+
+
+def test_get_permission_description():
+    desc = get_permission_description(Permission.USER_CREATE)
+    assert "Create" in desc

--- a/backend/tests/test_core_utils.py
+++ b/backend/tests/test_core_utils.py
@@ -1,0 +1,47 @@
+import time
+from datetime import timedelta
+import pytest
+from app.core.security import (
+    get_password_hash,
+    verify_password,
+    generate_secure_token,
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+    check_password_strength,
+)
+
+
+def test_password_hash_and_verify():
+    password = "StrongPassw0rd!"
+    hashed = get_password_hash(password)
+    assert hashed != password
+    assert verify_password(password, hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_generate_secure_token_uniqueness():
+    token1 = generate_secure_token(16)
+    token2 = generate_secure_token(16)
+    assert len(token1) == 16
+    assert token1 != token2
+
+
+def test_jwt_token_creation_and_verification():
+    token = create_access_token("user123", expires_delta=timedelta(minutes=5))
+    assert verify_token(token) == "user123"
+    refresh = create_refresh_token("user123")
+    assert verify_token(refresh, token_type="refresh") == "user123"
+
+
+def test_jwt_token_expiration():
+    expired = create_access_token("user123", expires_delta=timedelta(seconds=-1))
+    time.sleep(1)
+    assert verify_token(expired) is None
+
+
+def test_check_password_strength():
+    weak = check_password_strength("abc")
+    assert not weak["is_strong"]
+    strong = check_password_strength("VeryStr0ng!Pass")
+    assert strong["is_strong"]

--- a/backend/tests/test_model_service_utils.py
+++ b/backend/tests/test_model_service_utils.py
@@ -1,0 +1,97 @@
+import pytest
+from datetime import datetime, timedelta
+from io import BytesIO
+from fastapi import UploadFile
+from fastapi import HTTPException
+
+from app.schemas.user import UserCreate, PasswordChange
+from app.models.user import User
+from app.services.file_service import FileService
+from app.core.config import settings
+
+
+def test_username_and_password_validation():
+    valid = UserCreate(
+        email="valid@example.com",
+        username="valid_user",
+        first_name="Val",
+        last_name="User",
+        password="Strongpass123"
+    )
+    assert valid.username == "valid_user"
+
+    with pytest.raises(Exception):
+        UserCreate(
+            email="bad@example.com",
+            username="ab",
+            first_name="Bad",
+            last_name="User",
+            password="Strongpass123"
+        )
+
+    with pytest.raises(Exception):
+        UserCreate(
+            email="bad2@example.com",
+            username="bad*name",
+            first_name="Bad",
+            last_name="User",
+            password="Strongpass123"
+        )
+
+    with pytest.raises(Exception):
+        UserCreate(
+            email="bad3@example.com",
+            username="goodname",
+            first_name="Bad",
+            last_name="User",
+            password="short"
+        )
+
+    with pytest.raises(Exception):
+        UserCreate(
+            email="bad4@example.com",
+            username="goodname",
+            first_name="Bad",
+            last_name="User",
+            password="nonumbershereabcdef"
+        )
+
+
+def test_password_change_validation():
+    PasswordChange(current_password="old", new_password="Validpass123")
+    with pytest.raises(Exception):
+        PasswordChange(current_password="old", new_password="short")
+
+
+def test_user_is_locked_property():
+    future = datetime.utcnow() + timedelta(minutes=5)
+    past = datetime.utcnow() - timedelta(minutes=5)
+
+    assert User(account_locked_until=future).is_locked
+    assert not User(account_locked_until=past).is_locked
+    assert not User(account_locked_until=None).is_locked
+
+
+def test_file_service_helpers(tmp_path):
+    settings.UPLOAD_FOLDER = str(tmp_path)
+    service = FileService(db=None)
+
+    assert service.get_file_type("test.xlsx").value == "excel"
+    assert service.get_file_type("test.csv").value == "csv"
+    with pytest.raises(ValueError):
+        service.get_file_type("test.txt")
+
+    fname1 = service.generate_unique_filename("orig.xlsx")
+    fname2 = service.generate_unique_filename("orig.xlsx")
+    assert fname1 != fname2 and fname1.endswith(".xlsx")
+
+    small = UploadFile(file=BytesIO(b"123"), filename="small.csv", size=3, headers={"content-type": "text/csv"})
+    service.validate_file(small)
+
+    big = UploadFile(file=BytesIO(b"data"), filename="big.csv", size=service.max_file_size + 1, headers={"content-type": "text/csv"})
+    with pytest.raises(HTTPException):
+        service.validate_file(big)
+
+    bad = UploadFile(file=BytesIO(b"123"), filename="bad.exe", size=3, headers={"content-type": "application/octet-stream"})
+    with pytest.raises(HTTPException):
+        service.validate_file(bad)


### PR DESCRIPTION
## Summary
- add tests for user schema validation and FileService helpers
- verify user lock status logic

## Testing
- `pytest -q` *(fails: Coverage failure: total of 35 is less than fail-under=80)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed7fb15c8327b833191ac164ac27