### PR TITLE
Add initial unit tests for settings and models

### DIFF
--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -34,3 +34,24 @@ def test_permission_checker_basic():
 def test_get_permission_description():
     desc = get_permission_description(Permission.USER_CREATE)
     assert "Create" in desc
+
+def test_assemble_cors_origins_list():
+    settings = Settings(BACKEND_CORS_ORIGINS=["http://a.com", "http://b.com"])
+    assert settings.BACKEND_CORS_ORIGINS == "http://a.com,http://b.com"
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+
+
+def test_has_permission_invalid_role():
+    assert not PermissionChecker.has_permission(["invalid"], Permission.USER_CREATE)
+
+
+def test_get_user_permissions_invalid_role():
+    assert PermissionChecker.get_user_permissions(["bad"]) == set()
+
+
+def test_can_access_resource_denied():
+    viewer = [RoleType.VIEWER.value]
+    assert not PermissionChecker.can_access_resource(
+        viewer, 2, 1, Permission.MODEL_UPDATE
+    )
+

--- a/backend/tests/test_model_repr.py
+++ b/backend/tests/test_model_repr.py
@@ -1,0 +1,48 @@
+from app.models.role import Role, RoleType, UserRole
+from app.models.file import UploadedFile, FileStatus, ProcessingLog
+from app.models.audit import AuditLog, AuditAction
+from app.models.user import User
+
+
+def test_role_repr():
+    role = Role(id=1, name=RoleType.ADMIN, display_name="Admin")
+    assert "Role" in repr(role)
+
+
+def test_userrole_repr():
+    ur = UserRole(user_id=1, role_id=2)
+    assert "UserRole" in repr(ur)
+
+
+def test_uploadedfile_repr():
+    file = UploadedFile(
+        id=1,
+        filename="file.xlsx",
+        stored_filename="s",
+        original_filename="o",
+        file_path="/tmp/o",
+        file_size=10,
+        user_id=1,
+        status=FileStatus.UPLOADED,
+    )
+    assert "UploadedFile" in repr(file)
+
+
+def test_processinglog_repr():
+    log = ProcessingLog(id=1, file_id=1, step="parse", message="ok", level="info")
+    assert "ProcessingLog" in repr(log)
+
+
+def test_auditlog_repr():
+    log = AuditLog(id=1, user_id=1, action=AuditAction.LOGIN, success="success")
+    assert "AuditLog" in repr(log)
+
+
+def test_user_repr_and_is_locked():
+    user = User(id=1, email="a@b.com", username="ab")
+    assert "User" in repr(user)
+    user.account_locked_until = None
+    assert user.is_locked is False
+    from datetime import datetime, timedelta
+    user.account_locked_until = datetime.utcnow() + timedelta(minutes=5)
+    assert user.is_locked is True

--- a/backend/tests/test_schema_validators.py
+++ b/backend/tests/test_schema_validators.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.parameter import ParameterBase
+from app.schemas.report import ReportScheduleBase
+from app.models.parameter import ParameterType, ParameterCategory, SensitivityLevel
+from app.schemas.report import ExportFormat
+
+
+def test_parameter_base_range_validation():
+    with pytest.raises(ValidationError):
+        ParameterBase(name="p", min_value=5, max_value=3)
+
+    p = ParameterBase(name="p", min_value=1, max_value=2)
+    assert p.max_value == 2
+
+
+def test_report_schedule_email_validation():
+    with pytest.raises(ValidationError):
+        ReportScheduleBase(
+            name="r",
+            cron_expression="* * * * *",
+            template_id=1,
+            email_recipients=["bad-email"]
+        )
+
+    rs = ReportScheduleBase(
+        name="r",
+        cron_expression="* * * * *",
+        template_id=1,
+        email_recipients=["valid@example.com"],
+    )
+    assert rs.email_recipients == ["valid@example.com"]
+


### PR DESCRIPTION
## Summary
- add coverage tests for config and permission edge cases
- add model repr tests and user lock property
- add validation checks for parameters and reports

## Testing
- `pytest tests/test_model_repr.py tests/test_schema_validators.py tests/test_config_permissions.py --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68850f1c2d008327bb1dca8bb9394732