### PR TITLE
Add smoke tests for scheduled tasks

### DIFF
--- a/backend/tests/test_advanced_validator.py
+++ b/backend/tests/test_advanced_validator.py
@@ -1,0 +1,23 @@
+import types
+import app.services.advanced_validator as av
+
+class DummySheet:
+    def __init__(self):
+        self.sheet_type = av.SheetType.PROFIT_LOSS
+
+class DummyParsed:
+    def __init__(self):
+        self.sheets = []
+
+class DummyParsedWithSheet(DummyParsed):
+    def __init__(self):
+        self.sheets = [types.SimpleNamespace(sheet_type=av.SheetType.PROFIT_LOSS, name="P&L", cells=[], header_row=1)]
+
+
+def test_validate_template_no_sheets():
+    validator = av.AdvancedValidator()
+    res = validator.validate_template(DummyParsed())
+    assert not res.is_valid
+    assert res.validation_errors
+
+

--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -34,3 +34,24 @@ def test_permission_checker_basic():
 def test_get_permission_description():
     desc = get_permission_description(Permission.USER_CREATE)
     assert "Create" in desc
+
+def test_assemble_cors_origins_list():
+    settings = Settings(BACKEND_CORS_ORIGINS=["http://a.com", "http://b.com"])
+    assert settings.BACKEND_CORS_ORIGINS == "http://a.com,http://b.com"
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+
+
+def test_has_permission_invalid_role():
+    assert not PermissionChecker.has_permission(["invalid"], Permission.USER_CREATE)
+
+
+def test_get_user_permissions_invalid_role():
+    assert PermissionChecker.get_user_permissions(["bad"]) == set()
+
+
+def test_can_access_resource_denied():
+    viewer = [RoleType.VIEWER.value]
+    assert not PermissionChecker.can_access_resource(
+        viewer, 2, 1, Permission.MODEL_UPDATE
+    )
+

--- a/backend/tests/test_model_repr.py
+++ b/backend/tests/test_model_repr.py
@@ -1,0 +1,48 @@
+from app.models.role import Role, RoleType, UserRole
+from app.models.file import UploadedFile, FileStatus, ProcessingLog
+from app.models.audit import AuditLog, AuditAction
+from app.models.user import User
+
+
+def test_role_repr():
+    role = Role(id=1, name=RoleType.ADMIN, display_name="Admin")
+    assert "Role" in repr(role)
+
+
+def test_userrole_repr():
+    ur = UserRole(user_id=1, role_id=2)
+    assert "UserRole" in repr(ur)
+
+
+def test_uploadedfile_repr():
+    file = UploadedFile(
+        id=1,
+        filename="file.xlsx",
+        stored_filename="s",
+        original_filename="o",
+        file_path="/tmp/o",
+        file_size=10,
+        user_id=1,
+        status=FileStatus.UPLOADED,
+    )
+    assert "UploadedFile" in repr(file)
+
+
+def test_processinglog_repr():
+    log = ProcessingLog(id=1, file_id=1, step="parse", message="ok", level="info")
+    assert "ProcessingLog" in repr(log)
+
+
+def test_auditlog_repr():
+    log = AuditLog(id=1, user_id=1, action=AuditAction.LOGIN, success="success")
+    assert "AuditLog" in repr(log)
+
+
+def test_user_repr_and_is_locked():
+    user = User(id=1, email="a@b.com", username="ab")
+    assert "User" in repr(user)
+    user.account_locked_until = None
+    assert user.is_locked is False
+    from datetime import datetime, timedelta
+    user.account_locked_until = datetime.utcnow() + timedelta(minutes=5)
+    assert user.is_locked is True

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1,0 +1,82 @@
+import types
+from datetime import datetime
+
+import pytest
+
+import app.tasks.scheduled_tasks as st
+
+class DummyCleanupService:
+    def __init__(self):
+        pass
+    async def run_scheduled_cleanup(self):
+        return {"total_files_deleted": 2, "total_storage_freed_mb": 1.2}
+    def get_cleanup_statistics(self):
+        return {"reclaimable_storage_mb": 50, "eligible_for_cleanup": 5, "storage_used_mb": 500}
+
+class DummySend:
+    def __init__(self):
+        self.calls = []
+    def delay(self, *args):
+        self.calls.append(args)
+
+class DummySession:
+    def execute(self, q):
+        return 1
+
+class DummySessionLocal:
+    def __enter__(self):
+        return DummySession()
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyCloud:
+    def get_storage_stats(self):
+        return {"used": 10}
+
+class DummyScanner:
+    def get_scanner_status(self):
+        return {"available": ["basic"]}
+
+class DummyAnalytics:
+    def __init__(self, db):
+        pass
+    def get_dashboard_summary(self, days):
+        return {"days": days}
+    def get_processing_overview(self, days):
+        return {"overview": days}
+    def get_performance_metrics(self, days):
+        return {"perf": days}
+
+@pytest.fixture(autouse=True)
+def patch_deps(monkeypatch):
+    dummy_send = DummySend()
+    monkeypatch.setattr(st, "FileCleanupService", DummyCleanupService)
+    monkeypatch.setattr(st, "send_system_alert", dummy_send)
+    monkeypatch.setattr(st, "SessionLocal", lambda: DummySessionLocal())
+    import sys
+    sys.modules['app.services.cloud_storage'] = types.SimpleNamespace(CloudStorageManager=DummyCloud)
+    sys.modules['app.services.virus_scanner'] = types.SimpleNamespace(VirusScanManager=DummyScanner)
+    sys.modules['app.services.analytics_service'] = types.SimpleNamespace(AnalyticsService=DummyAnalytics)
+    return dummy_send
+
+
+def test_cleanup_expired_files(patch_deps):
+    result = st.cleanup_expired_files()
+    assert result["total_files_deleted"] == 2
+    assert patch_deps.calls  # notification sent
+
+
+def test_generate_cleanup_report(patch_deps):
+    report = st.generate_cleanup_report()
+    assert report["statistics"]["reclaimable_storage_mb"] == 50
+
+
+def test_health_check(patch_deps):
+    status = st.health_check()
+    assert status["overall_status"] == "healthy"
+    assert "database" in status["services"]
+
+
+def test_update_analytics_cache(patch_deps):
+    res = st.update_analytics_cache()
+    assert res["success"] is True

--- a/backend/tests/test_schema_validators.py
+++ b/backend/tests/test_schema_validators.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.parameter import ParameterBase
+from app.schemas.report import ReportScheduleBase
+from app.models.parameter import ParameterType, ParameterCategory, SensitivityLevel
+from app.schemas.report import ExportFormat
+
+
+def test_parameter_base_range_validation():
+    with pytest.raises(ValidationError):
+        ParameterBase(name="p", min_value=5, max_value=3)
+
+    p = ParameterBase(name="p", min_value=1, max_value=2)
+    assert p.max_value == 2
+
+
+def test_report_schedule_email_validation():
+    with pytest.raises(ValidationError):
+        ReportScheduleBase(
+            name="r",
+            cron_expression="* * * * *",
+            template_id=1,
+            email_recipients=["bad-email"]
+        )
+
+    rs = ReportScheduleBase(
+        name="r",
+        cron_expression="* * * * *",
+        template_id=1,
+        email_recipients=["valid@example.com"],
+    )
+    assert rs.email_recipients == ["valid@example.com"]
+

--- a/lite_tests/test_config_permissions.py
+++ b/lite_tests/test_config_permissions.py
@@ -21,7 +21,9 @@ from app.core.permissions import (
 )
 
 
-def test_get_cors_origins_parsing():
+def test_get_cors_origins_parsing(monkeypatch):
+    """Ensure CORS list parsing works even if other env vars are set."""
+    monkeypatch.delenv("VIRUS_SCANNERS", raising=False)
     settings = Settings(BACKEND_CORS_ORIGINS="http://a.com,http://b.com")
     assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
     star = Settings(BACKEND_CORS_ORIGINS="*")


### PR DESCRIPTION
## Summary
- test config CORS parsing without stray env variables
- add smoke tests covering scheduled Celery tasks
- cover basic validation behavior of advanced validator

## Testing
- `pytest backend/tests/test_model_repr.py backend/tests/test_schema_validators.py backend/tests/test_config_permissions.py backend/tests/test_scheduled_tasks.py backend/tests/test_advanced_validator.py --cov=app --cov-config=/dev/null --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68850f1c2d008327bb1dca8bb9394732