### PR TITLE
Add security and exporter tests

### DIFF
--- a/backend/tests/test_advanced_validator.py
+++ b/backend/tests/test_advanced_validator.py
@@ -1,0 +1,23 @@
+import types
+import app.services.advanced_validator as av
+
+class DummySheet:
+    def __init__(self):
+        self.sheet_type = av.SheetType.PROFIT_LOSS
+
+class DummyParsed:
+    def __init__(self):
+        self.sheets = []
+
+class DummyParsedWithSheet(DummyParsed):
+    def __init__(self):
+        self.sheets = [types.SimpleNamespace(sheet_type=av.SheetType.PROFIT_LOSS, name="P&L", cells=[], header_row=1)]
+
+
+def test_validate_template_no_sheets():
+    validator = av.AdvancedValidator()
+    res = validator.validate_template(DummyParsed())
+    assert not res.is_valid
+    assert res.validation_errors
+
+

--- a/backend/tests/test_advanced_validator_additional.py
+++ b/backend/tests/test_advanced_validator_additional.py
@@ -1,0 +1,21 @@
+from app.services.advanced_validator import AdvancedValidator, TemplateType
+
+
+def test_get_template_requirements_has_keys():
+    validator = AdvancedValidator()
+    reqs = validator.get_template_requirements(TemplateType.PROFIT_LOSS)
+    assert reqs["template_type"] == TemplateType.PROFIT_LOSS.value
+    assert "required_columns" in reqs
+    assert "required_sections" in reqs
+
+
+def test_calculate_column_match_confidence_exact():
+    validator = AdvancedValidator()
+    assert validator._calculate_column_match_confidence("revenue", "revenue") == 1.0
+
+
+def test_infer_column_data_type_variants():
+    validator = AdvancedValidator()
+    assert validator._infer_column_data_type([1, 2, 3]) == "numeric"
+    assert validator._infer_column_data_type(["a", "b"]) == "text"
+    assert validator._infer_column_data_type([1, "b"]) == "mixed"

--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -34,3 +34,24 @@ def test_permission_checker_basic():
 def test_get_permission_description():
     desc = get_permission_description(Permission.USER_CREATE)
     assert "Create" in desc
+
+def test_assemble_cors_origins_list():
+    settings = Settings(BACKEND_CORS_ORIGINS=["http://a.com", "http://b.com"])
+    assert settings.BACKEND_CORS_ORIGINS == "http://a.com,http://b.com"
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+
+
+def test_has_permission_invalid_role():
+    assert not PermissionChecker.has_permission(["invalid"], Permission.USER_CREATE)
+
+
+def test_get_user_permissions_invalid_role():
+    assert PermissionChecker.get_user_permissions(["bad"]) == set()
+
+
+def test_can_access_resource_denied():
+    viewer = [RoleType.VIEWER.value]
+    assert not PermissionChecker.can_access_resource(
+        viewer, 2, 1, Permission.MODEL_UPDATE
+    )
+

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,0 +1,18 @@
+from app.models.base import get_db
+
+
+def test_get_db_yields_session(monkeypatch):
+    events = []
+
+    class DummySession:
+        def __init__(self):
+            events.append("created")
+        def close(self):
+            events.append("closed")
+
+    monkeypatch.setattr('app.models.base.SessionLocal', lambda: DummySession())
+    gen = get_db()
+    next(gen)
+    assert events == ["created"]
+    gen.close()
+    assert events == ["created", "closed"]

--- a/backend/tests/test_exporters.py
+++ b/backend/tests/test_exporters.py
@@ -1,0 +1,17 @@
+import os
+from app.services.excel_exporter import ExcelExporter
+from app.services.pdf_generator import PDFReportGenerator
+
+
+def test_excel_exporter_creates_file(tmp_path):
+    exporter = ExcelExporter(output_dir=tmp_path)
+    data = {"summary": {"metrics": {"revenue": 1000}}, "pl": {"metrics": {"profit": 200}}}
+    path = exporter.export_financial_data(data)
+    assert os.path.exists(path)
+
+
+def test_pdf_generator_creates_file(tmp_path):
+    generator = PDFReportGenerator(output_dir=tmp_path)
+    data = {"metrics": {"revenue": 1000}, "charts": {"revenue_trend": [{"period": "Q1", "value": 100}, {"period": "Q2", "value": 150}]}}
+    path = generator.generate_financial_report(data)
+    assert os.path.exists(path)

--- a/backend/tests/test_file_cleanup_policy.py
+++ b/backend/tests/test_file_cleanup_policy.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from app.services.file_cleanup import FileRetentionPolicy
+from app.models.file import FileStatus
+
+
+def make_file(created_at, file_type="excel", status=FileStatus.COMPLETED, size=1024*1024):
+    return SimpleNamespace(file_size=size, file_type=file_type, status=status, created_at=created_at)
+
+
+def test_policy_applies_by_status():
+    policy = FileRetentionPolicy("p", "d", 1, applies_to_status=[FileStatus.COMPLETED])
+    file = make_file(datetime.utcnow() - timedelta(days=2))
+    assert policy.applies_to_file(file)
+    file.status = FileStatus.FAILED
+    assert not policy.applies_to_file(file)
+
+
+def test_policy_size_and_user_tier():
+    policy = FileRetentionPolicy("p", "d", 1, size_threshold_mb=2, user_tier_specific="premium")
+    file = make_file(datetime.utcnow(), size=3*1024*1024)
+    user = SimpleNamespace(tier="premium")
+    assert policy.applies_to_file(file, user)
+    user.tier = "basic"
+    assert not policy.applies_to_file(file, user)
+    file.file_size = 1*1024*1024
+    assert not policy.applies_to_file(file, user)
+
+
+def test_is_file_expired():
+    policy = FileRetentionPolicy("p", "d", 1)
+    old_file = make_file(datetime.utcnow() - timedelta(days=2))
+    new_file = make_file(datetime.utcnow())
+    assert policy.is_file_expired(old_file)
+    assert not policy.is_file_expired(new_file)

--- a/backend/tests/test_model_repr.py
+++ b/backend/tests/test_model_repr.py
@@ -1,0 +1,48 @@
+from app.models.role import Role, RoleType, UserRole
+from app.models.file import UploadedFile, FileStatus, ProcessingLog
+from app.models.audit import AuditLog, AuditAction
+from app.models.user import User
+
+
+def test_role_repr():
+    role = Role(id=1, name=RoleType.ADMIN, display_name="Admin")
+    assert "Role" in repr(role)
+
+
+def test_userrole_repr():
+    ur = UserRole(user_id=1, role_id=2)
+    assert "UserRole" in repr(ur)
+
+
+def test_uploadedfile_repr():
+    file = UploadedFile(
+        id=1,
+        filename="file.xlsx",
+        stored_filename="s",
+        original_filename="o",
+        file_path="/tmp/o",
+        file_size=10,
+        user_id=1,
+        status=FileStatus.UPLOADED,
+    )
+    assert "UploadedFile" in repr(file)
+
+
+def test_processinglog_repr():
+    log = ProcessingLog(id=1, file_id=1, step="parse", message="ok", level="info")
+    assert "ProcessingLog" in repr(log)
+
+
+def test_auditlog_repr():
+    log = AuditLog(id=1, user_id=1, action=AuditAction.LOGIN, success="success")
+    assert "AuditLog" in repr(log)
+
+
+def test_user_repr_and_is_locked():
+    user = User(id=1, email="a@b.com", username="ab")
+    assert "User" in repr(user)
+    user.account_locked_until = None
+    assert user.is_locked is False
+    from datetime import datetime, timedelta
+    user.account_locked_until = datetime.utcnow() + timedelta(minutes=5)
+    assert user.is_locked is True

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1,0 +1,82 @@
+import types
+from datetime import datetime
+
+import pytest
+
+import app.tasks.scheduled_tasks as st
+
+class DummyCleanupService:
+    def __init__(self):
+        pass
+    async def run_scheduled_cleanup(self):
+        return {"total_files_deleted": 2, "total_storage_freed_mb": 1.2}
+    def get_cleanup_statistics(self):
+        return {"reclaimable_storage_mb": 50, "eligible_for_cleanup": 5, "storage_used_mb": 500}
+
+class DummySend:
+    def __init__(self):
+        self.calls = []
+    def delay(self, *args):
+        self.calls.append(args)
+
+class DummySession:
+    def execute(self, q):
+        return 1
+
+class DummySessionLocal:
+    def __enter__(self):
+        return DummySession()
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyCloud:
+    def get_storage_stats(self):
+        return {"used": 10}
+
+class DummyScanner:
+    def get_scanner_status(self):
+        return {"available": ["basic"]}
+
+class DummyAnalytics:
+    def __init__(self, db):
+        pass
+    def get_dashboard_summary(self, days):
+        return {"days": days}
+    def get_processing_overview(self, days):
+        return {"overview": days}
+    def get_performance_metrics(self, days):
+        return {"perf": days}
+
+@pytest.fixture(autouse=True)
+def patch_deps(monkeypatch):
+    dummy_send = DummySend()
+    monkeypatch.setattr(st, "FileCleanupService", DummyCleanupService)
+    monkeypatch.setattr(st, "send_system_alert", dummy_send)
+    monkeypatch.setattr(st, "SessionLocal", lambda: DummySessionLocal())
+    import sys
+    sys.modules['app.services.cloud_storage'] = types.SimpleNamespace(CloudStorageManager=DummyCloud)
+    sys.modules['app.services.virus_scanner'] = types.SimpleNamespace(VirusScanManager=DummyScanner)
+    sys.modules['app.services.analytics_service'] = types.SimpleNamespace(AnalyticsService=DummyAnalytics)
+    return dummy_send
+
+
+def test_cleanup_expired_files(patch_deps):
+    result = st.cleanup_expired_files()
+    assert result["total_files_deleted"] == 2
+    assert patch_deps.calls  # notification sent
+
+
+def test_generate_cleanup_report(patch_deps):
+    report = st.generate_cleanup_report()
+    assert report["statistics"]["reclaimable_storage_mb"] == 50
+
+
+def test_health_check(patch_deps):
+    status = st.health_check()
+    assert status["overall_status"] == "healthy"
+    assert "database" in status["services"]
+
+
+def test_update_analytics_cache(patch_deps):
+    res = st.update_analytics_cache()
+    assert res["success"] is True

--- a/backend/tests/test_schema_validators.py
+++ b/backend/tests/test_schema_validators.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.parameter import ParameterBase
+from app.schemas.report import ReportScheduleBase
+from app.models.parameter import ParameterType, ParameterCategory, SensitivityLevel
+from app.schemas.report import ExportFormat
+
+
+def test_parameter_base_range_validation():
+    with pytest.raises(ValidationError):
+        ParameterBase(name="p", min_value=5, max_value=3)
+
+    p = ParameterBase(name="p", min_value=1, max_value=2)
+    assert p.max_value == 2
+
+
+def test_report_schedule_email_validation():
+    with pytest.raises(ValidationError):
+        ReportScheduleBase(
+            name="r",
+            cron_expression="* * * * *",
+            template_id=1,
+            email_recipients=["bad-email"]
+        )
+
+    rs = ReportScheduleBase(
+        name="r",
+        cron_expression="* * * * *",
+        template_id=1,
+        email_recipients=["valid@example.com"],
+    )
+    assert rs.email_recipients == ["valid@example.com"]
+

--- a/backend/tests/test_security_tokens.py
+++ b/backend/tests/test_security_tokens.py
@@ -1,0 +1,31 @@
+import pytest
+from datetime import timedelta
+from app.core import security
+
+
+def test_password_hash_and_verify():
+    password = "StrongPass123!"
+    hashed = security.get_password_hash(password)
+    assert hashed != password
+    assert security.verify_password(password, hashed)
+    assert not security.verify_password("wrong", hashed)
+
+
+def test_token_creation_and_verification():
+    token = security.create_access_token("user1", expires_delta=timedelta(minutes=5))
+    assert security.verify_token(token) == "user1"
+
+
+def test_email_and_password_reset_tokens():
+    email = "test@example.com"
+    email_token = security.create_email_verification_token(email)
+    reset_token = security.create_password_reset_token(email)
+    assert security.verify_email_verification_token(email_token) == email
+    assert security.verify_password_reset_token(reset_token) == email
+
+
+def test_password_strength_scores():
+    weak = "123"
+    strong = "StrongerPass123!"
+    assert not security.check_password_strength(weak)["is_strong"]
+    assert security.check_password_strength(strong)["is_strong"]

--- a/backend/tests/test_user_schemas.py
+++ b/backend/tests/test_user_schemas.py
@@ -1,0 +1,48 @@
+import pytest
+from app.schemas.user import UserBase, UserCreate, UserUpdate, PasswordChange, PasswordResetConfirm
+
+
+def test_username_validations():
+    # valid username
+    assert UserBase(username="good-user", email="a@b.com").username == "good-user"
+
+    # too short
+    with pytest.raises(ValueError):
+        UserBase(username="ab", email="a@b.com")
+
+    # invalid characters
+    with pytest.raises(ValueError):
+        UserBase(username="bad*name", email="a@b.com")
+
+    # too long
+    with pytest.raises(ValueError):
+        UserBase(username="a" * 51, email="a@b.com")
+
+
+def test_name_validations():
+    ok = UserBase(username="user123", email="e@e.com", first_name=" John ", last_name=" Doe ")
+    assert ok.first_name == "John"
+    assert ok.last_name == "Doe"
+
+    with pytest.raises(ValueError):
+        UserBase(username="user123", email="e@e.com", first_name="", last_name="Doe")
+
+    with pytest.raises(ValueError):
+        UserUpdate(first_name="A" * 51)
+
+
+def test_password_validations_create_change_reset():
+    # valid passwords pass
+    UserCreate(username="user1", email="a@b.com", password="strongpass123")
+    PasswordChange(current_password="old", new_password="complex123zz")
+    PasswordResetConfirm(token="abc", new_password="complex123zz")
+
+    # invalid cases
+    with pytest.raises(ValueError):
+        UserCreate(username="user1", email="a@b.com", password="short")
+
+    with pytest.raises(ValueError):
+        PasswordChange(current_password="old", new_password="nonumbershere")
+
+    with pytest.raises(ValueError):
+        PasswordResetConfirm(token="abc", new_password="NOLOWERS123456")

--- a/lite_tests/test_config_permissions.py
+++ b/lite_tests/test_config_permissions.py
@@ -21,7 +21,9 @@ from app.core.permissions import (
 )
 
 
-def test_get_cors_origins_parsing():
+def test_get_cors_origins_parsing(monkeypatch):
+    """Ensure CORS list parsing works even if other env vars are set."""
+    monkeypatch.delenv("VIRUS_SCANNERS", raising=False)
     settings = Settings(BACKEND_CORS_ORIGINS="http://a.com,http://b.com")
     assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
     star = Settings(BACKEND_CORS_ORIGINS="*")


### PR DESCRIPTION
## Summary
- verify password hashing and JWT token helpers
- cover validator helper methods on AdvancedValidator
- ensure file retention policy logic works
- smoke test Excel and PDF exporters
- test DB session generator

## Testing
- `pytest backend/tests/test_model_repr.py backend/tests/test_schema_validators.py backend/tests/test_config_permissions.py backend/tests/test_scheduled_tasks.py backend/tests/test_advanced_validator.py backend/tests/test_user_schemas.py backend/tests/test_security_tokens.py backend/tests/test_advanced_validator_additional.py backend/tests/test_file_cleanup_policy.py backend/tests/test_exporters.py backend/tests/test_db_session.py -q --cov=app --cov-config=/dev/null --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68850f1c2d008327bb1dca8bb9394732