### PR TITLE
Expand service tests for cleanup and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ coverage/
 # Temporary files
 tmp/
 temp/
+
+# Coverage artifacts
+.coverage
+coverage.xml

--- a/backend/tests/test_additional_services.py
+++ b/backend/tests/test_additional_services.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from app.simple_module import add, subtract, divide
+import types
+import sys
+
+sys.modules.setdefault('scipy', types.ModuleType('scipy'))
+sys.modules['scipy'].stats = types.SimpleNamespace()
+
+from app.services.sensitivity_analyzer import (
+    SensitivityAnalyzer,
+    SensitivityResult,
+    SensitivityConfig,
+)
+from app.services.virus_scanner import BasicFileScanner, VirusScanManager
+
+
+def test_simple_module_operations():
+    assert add(2, 3) == 5
+    assert subtract(5, 1) == 4
+    assert divide(9, 3) == 3
+    with pytest.raises(ValueError):
+        divide(1, 0)
+
+
+@pytest.mark.asyncio
+async def test_sensitivity_analyzer_helpers():
+    analyzer = SensitivityAnalyzer(db=None)
+    corr = analyzer._calculate_correlation([1, 2, 3], [2, 4, 6])
+    assert pytest.approx(corr, 0.01) == 1.0
+    results = [
+        SensitivityResult(
+            parameter_id=1,
+            parameter_name="a",
+            base_value=1,
+            sensitivity_coefficient=0.5,
+            impact_range=(0.1, 0.5),
+        ),
+        SensitivityResult(
+            parameter_id=2,
+            parameter_name="b",
+            base_value=1,
+            sensitivity_coefficient=-0.2,
+            impact_range=(-0.2, 0.2),
+        ),
+    ]
+    tornado = await analyzer._generate_tornado_chart_data(results)
+    assert tornado["type"] == "tornado"
+    mc = await analyzer._generate_monte_carlo_chart_data(
+        np.array([1.0, 2.0, 3.0]),
+        [np.array([1, 2, 3]), np.array([0.5, 1.0, 1.5])],
+        [SensitivityConfig(parameter_id=1, min_value=0, max_value=1),
+         SensitivityConfig(parameter_id=2, min_value=0, max_value=1)],
+    )
+    assert mc["type"] == "monte_carlo"
+    spider = await analyzer._generate_spider_chart_data(
+        {1: {"parameter_name": "a", "variation_results": {0.1: 1}}},
+        [0.1],
+    )
+    assert spider["type"] == "spider"
+
+
+@pytest.mark.asyncio
+async def test_basic_file_scanner(tmp_path):
+    scanner = BasicFileScanner()
+    clean = tmp_path / "clean.txt"
+    clean.write_text("hello")
+    result = await scanner.scan_file(str(clean))
+    assert result.is_clean
+    eicar = tmp_path / "eicar.txt"
+    eicar.write_bytes(b"X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*")
+    result2 = await scanner.scan_file(str(eicar))
+    assert not result2.is_clean
+
+
+def test_virus_scan_manager_status(monkeypatch):
+    monkeypatch.setenv("VIRUS_SCANNERS", "basic")
+    manager = VirusScanManager()
+    status = manager.get_scanner_status()
+    assert "available_scanners" in status

--- a/backend/tests/test_advanced_validator.py
+++ b/backend/tests/test_advanced_validator.py
@@ -1,0 +1,23 @@
+import types
+import app.services.advanced_validator as av
+
+class DummySheet:
+    def __init__(self):
+        self.sheet_type = av.SheetType.PROFIT_LOSS
+
+class DummyParsed:
+    def __init__(self):
+        self.sheets = []
+
+class DummyParsedWithSheet(DummyParsed):
+    def __init__(self):
+        self.sheets = [types.SimpleNamespace(sheet_type=av.SheetType.PROFIT_LOSS, name="P&L", cells=[], header_row=1)]
+
+
+def test_validate_template_no_sheets():
+    validator = av.AdvancedValidator()
+    res = validator.validate_template(DummyParsed())
+    assert not res.is_valid
+    assert res.validation_errors
+
+

--- a/backend/tests/test_advanced_validator_additional.py
+++ b/backend/tests/test_advanced_validator_additional.py
@@ -1,0 +1,47 @@
+from app.services.advanced_validator import AdvancedValidator, TemplateType
+
+
+def test_get_template_requirements_has_keys():
+    validator = AdvancedValidator()
+    reqs = validator.get_template_requirements(TemplateType.PROFIT_LOSS)
+    assert reqs["template_type"] == TemplateType.PROFIT_LOSS.value
+    assert "required_columns" in reqs
+    assert "required_sections" in reqs
+
+
+def test_calculate_column_match_confidence_exact():
+    validator = AdvancedValidator()
+    assert validator._calculate_column_match_confidence("revenue", "revenue") == 1.0
+
+
+def test_infer_column_data_type_variants():
+    validator = AdvancedValidator()
+    assert validator._infer_column_data_type([1, 2, 3]) == "numeric"
+    assert validator._infer_column_data_type(["a", "b"]) == "text"
+    assert validator._infer_column_data_type([1, "b"]) == "mixed"
+
+def test_suggest_template_improvements_missing_columns():
+    from app.services.excel_parser import ParsedData, SheetInfo, CellInfo, DataType, SheetType
+
+    validator = AdvancedValidator()
+
+    sheet = SheetInfo(
+        name="P&L",
+        sheet_type=SheetType.PROFIT_LOSS,
+        max_row=2,
+        max_column=2,
+        header_row=1,
+        data_start_row=2,
+        has_formulas=False,
+        formula_count=0,
+        cells=[
+            CellInfo(address="A1", row=1, column=1, value="Account", data_type=DataType.TEXT),
+            CellInfo(address="B1", row=1, column=2, value="Amount", data_type=DataType.TEXT),
+            CellInfo(address="A2", row=2, column=1, value="Revenue", data_type=DataType.TEXT),
+            CellInfo(address="B2", row=2, column=2, value=100, data_type=DataType.NUMBER),
+        ],
+    )
+    parsed = ParsedData(file_name="f.xlsx", file_path="f.xlsx", file_size=1000, sheets=[sheet])
+    suggestions = validator.suggest_template_improvements(parsed)
+    assert any(s["type"] == "add_column" for s in suggestions["column_suggestions"])
+    assert suggestions["formula_suggestions"]  # formula recommendation when count is low

--- a/backend/tests/test_cloud_storage_services.py
+++ b/backend/tests/test_cloud_storage_services.py
@@ -1,0 +1,67 @@
+import io
+import os
+import types
+import pytest
+
+from app.services import cloud_storage
+
+
+@pytest.mark.asyncio
+async def test_local_storage_roundtrip(tmp_path):
+    service = cloud_storage.LocalStorageService()
+    service.storage_path = tmp_path
+
+    data = io.BytesIO(b"hello")
+    path = await service.upload_file(data, "nested/file.txt")
+    assert os.path.exists(path)
+
+    assert await service.file_exists("nested/file.txt")
+    content = await service.download_file("nested/file.txt")
+    assert content == b"hello"
+
+    url = await service.get_file_url("nested/file.txt")
+    assert url.endswith("nested/file.txt")
+
+    assert await service.delete_file("nested/file.txt")
+    assert not await service.file_exists("nested/file.txt")
+
+
+class DummyS3Client:
+    def __init__(self):
+        self.store = {}
+
+    def upload_fileobj(self, fileobj, bucket, key, ExtraArgs=None):
+        self.store[key] = fileobj.read()
+
+    def get_object(self, Bucket, Key):
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def delete_object(self, Bucket, Key):
+        self.store.pop(Key, None)
+
+    def generate_presigned_url(self, client_method, Params, ExpiresIn):
+        return f"https://{Params['Bucket']}.s3.amazonaws.com/{Params['Key']}"
+
+    def head_object(self, Bucket, Key):
+        if Key not in self.store:
+            raise Exception("missing")
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_roundtrip(monkeypatch):
+    monkeypatch.setattr(cloud_storage, "AWS_AVAILABLE", True)
+    monkeypatch.setattr(
+        cloud_storage,
+        "boto3",
+        types.SimpleNamespace(client=lambda *args, **kwargs: DummyS3Client()),
+    )
+    monkeypatch.setattr(cloud_storage, "ClientError", Exception)
+
+    service = cloud_storage.S3StorageService()
+    await service.upload_file(io.BytesIO(b"data"), "f.txt")
+    assert await service.file_exists("f.txt")
+    assert await service.download_file("f.txt") == b"data"
+    url = await service.get_file_url("f.txt")
+    assert url.startswith("https://")
+    assert await service.delete_file("f.txt")
+    assert not await service.file_exists("f.txt")

--- a/backend/tests/test_config_permissions.py
+++ b/backend/tests/test_config_permissions.py
@@ -34,3 +34,35 @@ def test_permission_checker_basic():
 def test_get_permission_description():
     desc = get_permission_description(Permission.USER_CREATE)
     assert "Create" in desc
+
+def test_assemble_cors_origins_list():
+    settings = Settings(BACKEND_CORS_ORIGINS=["http://a.com", "http://b.com"])
+    assert settings.BACKEND_CORS_ORIGINS == "http://a.com,http://b.com"
+    assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
+
+
+def test_has_permission_invalid_role():
+    assert not PermissionChecker.has_permission(["invalid"], Permission.USER_CREATE)
+
+
+def test_get_user_permissions_invalid_role():
+    assert PermissionChecker.get_user_permissions(["bad"]) == set()
+
+
+def test_can_access_resource_denied():
+    viewer = [RoleType.VIEWER.value]
+    assert not PermissionChecker.can_access_resource(
+        viewer, 2, 1, Permission.MODEL_UPDATE
+    )
+
+
+def test_assemble_cors_origins_default_if_blank():
+    settings = Settings(BACKEND_CORS_ORIGINS="")
+    assert settings.get_cors_origins() == ["http://localhost:3000", "http://127.0.0.1:3000"]
+
+def test_can_access_resource_admin():
+    admin = [RoleType.ADMIN.value]
+    assert PermissionChecker.can_access_resource(
+        admin, 2, 1, Permission.MODEL_UPDATE
+    )
+

--- a/backend/tests/test_dashboard_metrics.py
+++ b/backend/tests/test_dashboard_metrics.py
@@ -1,0 +1,26 @@
+import pytest
+from app.services.dashboard_metrics import DashboardMetricsService
+
+
+def test_demo_overview_metrics():
+    service = DashboardMetricsService(db=None)
+    data = service._get_demo_overview_metrics()
+    assert "key_metrics" in data
+    assert "summary" in data
+
+
+def test_demo_pl_metrics():
+    service = DashboardMetricsService(db=None)
+    data = service._get_demo_pl_metrics()
+    assert data["metrics"]
+    assert "charts" in data
+    assert "data_quality" in data
+
+
+def test_demo_trends_and_kpis():
+    service = DashboardMetricsService(db=None)
+    trends = service._get_demo_trends("revenue")
+    assert "time_series" in trends
+    kpis = service._get_demo_kpis()
+    assert any(k["name"] == "ROE" for k in kpis["kpis"])
+

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,0 +1,18 @@
+from app.models.base import get_db
+
+
+def test_get_db_yields_session(monkeypatch):
+    events = []
+
+    class DummySession:
+        def __init__(self):
+            events.append("created")
+        def close(self):
+            events.append("closed")
+
+    monkeypatch.setattr('app.models.base.SessionLocal', lambda: DummySession())
+    gen = get_db()
+    next(gen)
+    assert events == ["created"]
+    gen.close()
+    assert events == ["created", "closed"]

--- a/backend/tests/test_exporters.py
+++ b/backend/tests/test_exporters.py
@@ -1,0 +1,47 @@
+import os
+from app.services.excel_exporter import ExcelExporter
+from app.services.pdf_generator import PDFReportGenerator
+
+
+def test_excel_exporter_creates_file(tmp_path):
+    exporter = ExcelExporter(output_dir=tmp_path)
+    data = {"summary": {"metrics": {"revenue": 1000}}, "pl": {"metrics": {"profit": 200}}}
+    path = exporter.export_financial_data(data)
+    assert os.path.exists(path)
+
+
+def test_pdf_generator_creates_file(tmp_path):
+    generator = PDFReportGenerator(output_dir=tmp_path)
+    data = {"metrics": {"revenue": 1000}, "charts": {"revenue_trend": [{"period": "Q1", "value": 100}, {"period": "Q2", "value": 150}]}}
+    path = generator.generate_financial_report(data)
+    assert os.path.exists(path)
+
+
+def test_export_raw_data_csv(tmp_path):
+    exporter = ExcelExporter(output_dir=tmp_path)
+    data = [
+        {"name": "A", "value": 1},
+        {"name": "B", "value": 2},
+    ]
+    path = exporter.export_raw_data_csv(data, filename="out.csv", include_metadata=False)
+    assert os.path.exists(path)
+    with open(path) as f:
+        lines = [line.strip() for line in f.readlines()]
+    assert lines[0] == "name,value"
+    assert lines[1] == "A,1"
+    assert lines[2] == "B,2"
+
+
+def test_pdf_format_currency_and_export_chart(tmp_path):
+    generator = PDFReportGenerator(output_dir=tmp_path)
+    assert generator._format_currency(500) == "$500.00"
+    assert generator._format_currency(1500) == "$1.5K"
+    assert generator._format_currency(2_000_000) == "$2.0M"
+    chart_data = {
+        "data": [
+            {"period": "Q1", "value": 1},
+            {"period": "Q2", "value": 2},
+        ]
+    }
+    img_path = generator.export_chart_as_image(chart_data, chart_type="line", filename="chart.png")
+    assert os.path.exists(img_path)

--- a/backend/tests/test_file_cleanup_policy.py
+++ b/backend/tests/test_file_cleanup_policy.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from app.services.file_cleanup import FileRetentionPolicy
+from app.models.file import FileStatus
+
+
+def make_file(created_at, file_type="excel", status=FileStatus.COMPLETED, size=1024*1024):
+    return SimpleNamespace(file_size=size, file_type=file_type, status=status, created_at=created_at)
+
+
+def test_policy_applies_by_status():
+    policy = FileRetentionPolicy("p", "d", 1, applies_to_status=[FileStatus.COMPLETED])
+    file = make_file(datetime.utcnow() - timedelta(days=2))
+    assert policy.applies_to_file(file)
+    file.status = FileStatus.FAILED
+    assert not policy.applies_to_file(file)
+
+
+def test_policy_size_and_user_tier():
+    policy = FileRetentionPolicy("p", "d", 1, size_threshold_mb=2, user_tier_specific="premium")
+    file = make_file(datetime.utcnow(), size=3*1024*1024)
+    user = SimpleNamespace(tier="premium")
+    assert policy.applies_to_file(file, user)
+    user.tier = "basic"
+    assert not policy.applies_to_file(file, user)
+    file.file_size = 1*1024*1024
+    assert not policy.applies_to_file(file, user)
+
+
+def test_is_file_expired():
+    policy = FileRetentionPolicy("p", "d", 1)
+    old_file = make_file(datetime.utcnow() - timedelta(days=2))
+    new_file = make_file(datetime.utcnow())
+    assert policy.is_file_expired(old_file)
+    assert not policy.is_file_expired(new_file)

--- a/backend/tests/test_file_cleanup_service.py
+++ b/backend/tests/test_file_cleanup_service.py
@@ -1,0 +1,31 @@
+import pytest
+from app.services.file_cleanup import FileCleanupService
+
+class DummyStorageManager:
+    async def delete_file(self, path):
+        return True
+
+@pytest.mark.asyncio
+async def test_run_scheduled_cleanup(monkeypatch):
+    async def fake_cleanup_expired(self, dry_run=False):
+        return {"files_deleted": 1, "storage_freed_mb": 0.5}
+
+    async def fake_cleanup_orphans(self, dry_run=False):
+        return {"orphaned_files_deleted": 2, "storage_freed_mb": 1.0}
+
+    async def fake_cleanup_logs(self, retention_days=30, dry_run=False):
+        return {"logs_deleted": 3}
+
+    monkeypatch.setattr(FileCleanupService, "cleanup_expired_files", fake_cleanup_expired)
+    monkeypatch.setattr(FileCleanupService, "cleanup_orphaned_files", fake_cleanup_orphans)
+    monkeypatch.setattr(FileCleanupService, "cleanup_processing_logs", fake_cleanup_logs)
+    monkeypatch.setattr(
+        FileCleanupService, "__init__", lambda self: setattr(self, "storage_manager", DummyStorageManager()) or setattr(self, "policies", [])
+    )
+
+    service = FileCleanupService()
+    result = await service.run_scheduled_cleanup()
+    assert result["success"] is True
+    assert result["total_files_deleted"] == 3
+    assert result["total_storage_freed_mb"] == 1.5
+

--- a/backend/tests/test_model_repr.py
+++ b/backend/tests/test_model_repr.py
@@ -1,0 +1,48 @@
+from app.models.role import Role, RoleType, UserRole
+from app.models.file import UploadedFile, FileStatus, ProcessingLog
+from app.models.audit import AuditLog, AuditAction
+from app.models.user import User
+
+
+def test_role_repr():
+    role = Role(id=1, name=RoleType.ADMIN, display_name="Admin")
+    assert "Role" in repr(role)
+
+
+def test_userrole_repr():
+    ur = UserRole(user_id=1, role_id=2)
+    assert "UserRole" in repr(ur)
+
+
+def test_uploadedfile_repr():
+    file = UploadedFile(
+        id=1,
+        filename="file.xlsx",
+        stored_filename="s",
+        original_filename="o",
+        file_path="/tmp/o",
+        file_size=10,
+        user_id=1,
+        status=FileStatus.UPLOADED,
+    )
+    assert "UploadedFile" in repr(file)
+
+
+def test_processinglog_repr():
+    log = ProcessingLog(id=1, file_id=1, step="parse", message="ok", level="info")
+    assert "ProcessingLog" in repr(log)
+
+
+def test_auditlog_repr():
+    log = AuditLog(id=1, user_id=1, action=AuditAction.LOGIN, success="success")
+    assert "AuditLog" in repr(log)
+
+
+def test_user_repr_and_is_locked():
+    user = User(id=1, email="a@b.com", username="ab")
+    assert "User" in repr(user)
+    user.account_locked_until = None
+    assert user.is_locked is False
+    from datetime import datetime, timedelta
+    user.account_locked_until = datetime.utcnow() + timedelta(minutes=5)
+    assert user.is_locked is True

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1,0 +1,82 @@
+import types
+from datetime import datetime
+
+import pytest
+
+import app.tasks.scheduled_tasks as st
+
+class DummyCleanupService:
+    def __init__(self):
+        pass
+    async def run_scheduled_cleanup(self):
+        return {"total_files_deleted": 2, "total_storage_freed_mb": 1.2}
+    def get_cleanup_statistics(self):
+        return {"reclaimable_storage_mb": 50, "eligible_for_cleanup": 5, "storage_used_mb": 500}
+
+class DummySend:
+    def __init__(self):
+        self.calls = []
+    def delay(self, *args):
+        self.calls.append(args)
+
+class DummySession:
+    def execute(self, q):
+        return 1
+
+class DummySessionLocal:
+    def __enter__(self):
+        return DummySession()
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyCloud:
+    def get_storage_stats(self):
+        return {"used": 10}
+
+class DummyScanner:
+    def get_scanner_status(self):
+        return {"available": ["basic"]}
+
+class DummyAnalytics:
+    def __init__(self, db):
+        pass
+    def get_dashboard_summary(self, days):
+        return {"days": days}
+    def get_processing_overview(self, days):
+        return {"overview": days}
+    def get_performance_metrics(self, days):
+        return {"perf": days}
+
+@pytest.fixture(autouse=True)
+def patch_deps(monkeypatch):
+    dummy_send = DummySend()
+    monkeypatch.setattr(st, "FileCleanupService", DummyCleanupService)
+    monkeypatch.setattr(st, "send_system_alert", dummy_send)
+    monkeypatch.setattr(st, "SessionLocal", lambda: DummySessionLocal())
+    import sys
+    sys.modules['app.services.cloud_storage'] = types.SimpleNamespace(CloudStorageManager=DummyCloud)
+    sys.modules['app.services.virus_scanner'] = types.SimpleNamespace(VirusScanManager=DummyScanner)
+    sys.modules['app.services.analytics_service'] = types.SimpleNamespace(AnalyticsService=DummyAnalytics)
+    return dummy_send
+
+
+def test_cleanup_expired_files(patch_deps):
+    result = st.cleanup_expired_files()
+    assert result["total_files_deleted"] == 2
+    assert patch_deps.calls  # notification sent
+
+
+def test_generate_cleanup_report(patch_deps):
+    report = st.generate_cleanup_report()
+    assert report["statistics"]["reclaimable_storage_mb"] == 50
+
+
+def test_health_check(patch_deps):
+    status = st.health_check()
+    assert status["overall_status"] == "healthy"
+    assert "database" in status["services"]
+
+
+def test_update_analytics_cache(patch_deps):
+    res = st.update_analytics_cache()
+    assert res["success"] is True

--- a/backend/tests/test_schema_validators.py
+++ b/backend/tests/test_schema_validators.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import ValidationError
+from app.schemas.parameter import ParameterBase
+from app.schemas.report import ReportScheduleBase
+from app.models.parameter import ParameterType, ParameterCategory, SensitivityLevel
+from app.schemas.report import ExportFormat
+
+
+def test_parameter_base_range_validation():
+    with pytest.raises(ValidationError):
+        ParameterBase(name="p", min_value=5, max_value=3)
+
+    p = ParameterBase(name="p", min_value=1, max_value=2)
+    assert p.max_value == 2
+
+
+def test_report_schedule_email_validation():
+    with pytest.raises(ValidationError):
+        ReportScheduleBase(
+            name="r",
+            cron_expression="* * * * *",
+            template_id=1,
+            email_recipients=["bad-email"]
+        )
+
+    rs = ReportScheduleBase(
+        name="r",
+        cron_expression="* * * * *",
+        template_id=1,
+        email_recipients=["valid@example.com"],
+    )
+    assert rs.email_recipients == ["valid@example.com"]
+

--- a/backend/tests/test_security_tokens.py
+++ b/backend/tests/test_security_tokens.py
@@ -1,0 +1,31 @@
+import pytest
+from datetime import timedelta
+from app.core import security
+
+
+def test_password_hash_and_verify():
+    password = "StrongPass123!"
+    hashed = security.get_password_hash(password)
+    assert hashed != password
+    assert security.verify_password(password, hashed)
+    assert not security.verify_password("wrong", hashed)
+
+
+def test_token_creation_and_verification():
+    token = security.create_access_token("user1", expires_delta=timedelta(minutes=5))
+    assert security.verify_token(token) == "user1"
+
+
+def test_email_and_password_reset_tokens():
+    email = "test@example.com"
+    email_token = security.create_email_verification_token(email)
+    reset_token = security.create_password_reset_token(email)
+    assert security.verify_email_verification_token(email_token) == email
+    assert security.verify_password_reset_token(reset_token) == email
+
+
+def test_password_strength_scores():
+    weak = "123"
+    strong = "StrongerPass123!"
+    assert not security.check_password_strength(weak)["is_strong"]
+    assert security.check_password_strength(strong)["is_strong"]

--- a/backend/tests/test_user_schemas.py
+++ b/backend/tests/test_user_schemas.py
@@ -1,0 +1,55 @@
+import pytest
+from app.schemas.user import UserBase, UserCreate, UserUpdate, PasswordChange, PasswordResetConfirm
+
+
+def test_username_validations():
+    # valid username
+    assert UserBase(username="good-user", email="a@b.com").username == "good-user"
+
+    # too short
+    with pytest.raises(ValueError):
+        UserBase(username="ab", email="a@b.com")
+
+    # invalid characters
+    with pytest.raises(ValueError):
+        UserBase(username="bad*name", email="a@b.com")
+
+    # too long
+    with pytest.raises(ValueError):
+        UserBase(username="a" * 51, email="a@b.com")
+
+
+def test_name_validations():
+    ok = UserBase(username="user123", email="e@e.com", first_name=" John ", last_name=" Doe ")
+    assert ok.first_name == "John"
+    assert ok.last_name == "Doe"
+
+    with pytest.raises(ValueError):
+        UserBase(username="user123", email="e@e.com", first_name="", last_name="Doe")
+
+    with pytest.raises(ValueError):
+        UserUpdate(first_name="A" * 51)
+
+
+def test_password_validations_create_change_reset():
+    # valid passwords pass
+    UserCreate(username="user1", email="a@b.com", password="strongpass123")
+    PasswordChange(current_password="old", new_password="complex123zz")
+    PasswordResetConfirm(token="abc", new_password="complex123zz")
+
+    # invalid cases
+    with pytest.raises(ValueError):
+        UserCreate(username="user1", email="a@b.com", password="short")
+
+    with pytest.raises(ValueError):
+        PasswordChange(current_password="old", new_password="nonumbershere")
+
+    with pytest.raises(ValueError):
+        PasswordResetConfirm(token="abc", new_password="NOLOWERS123456")
+
+
+def test_password_change_and_reset_nonumbers():
+    with pytest.raises(ValueError):
+        PasswordChange(current_password="old", new_password="weaknonumbers")
+    with pytest.raises(ValueError):
+        PasswordResetConfirm(token="t", new_password="weaknonumbers")

--- a/backend/tests/test_websocket_manager.py
+++ b/backend/tests/test_websocket_manager.py
@@ -1,0 +1,49 @@
+import pytest
+from app.core.websocket import ConnectionManager
+
+class DummyWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.sent = []
+    async def accept(self):
+        self.accepted = True
+    async def send_text(self, text):
+        self.sent.append(text)
+
+@pytest.mark.asyncio
+async def test_connection_manager_basic():
+    manager = ConnectionManager()
+    ws = DummyWebSocket()
+    await manager.connect(ws, user_id=1)
+    assert 1 in manager.get_connected_users()
+    await manager.send_to_user(1, {"hello": "world"})
+    assert ws.sent and "hello" in ws.sent[-1]
+    assert manager.get_connection_count() == 1
+    manager.disconnect(ws, user_id=1)
+    assert manager.get_connected_users() == []
+    assert manager.get_connection_count() == 0
+
+@pytest.mark.asyncio
+async def test_file_subscription_and_broadcast():
+    manager = ConnectionManager()
+    ws = DummyWebSocket()
+    await manager.connect(ws, user_id=1)
+    await manager.subscribe_to_file(1, 42)
+    await manager.broadcast_file_status(42, {"state": "done"}, user_id=1)
+    assert any("file_status_update" in msg for msg in ws.sent)
+    await manager.unsubscribe_from_file(1, 42)
+    manager.disconnect(ws, user_id=1)
+
+@pytest.mark.asyncio
+async def test_task_subscription_and_notification():
+    manager = ConnectionManager()
+    ws = DummyWebSocket()
+    await manager.connect(ws, user_id=2)
+    await manager.subscribe_to_task(2, "task1")
+    await manager.broadcast_task_progress("task1", {"progress": 50}, user_id=2)
+    await manager.send_notification(2, {"text": "hi"})
+    assert any("task_progress_update" in m for m in ws.sent)
+    assert any("notification" in m for m in ws.sent)
+    await manager.unsubscribe_from_task(2, "task1")
+    manager.disconnect(ws, user_id=2)
+

--- a/lite_tests/test_cloud_manager.py
+++ b/lite_tests/test_cloud_manager.py
@@ -1,0 +1,93 @@
+import sys
+import types
+
+# Provide minimal stubs to satisfy imports
+mock_file = types.ModuleType('app.models.file')
+class UploadedFile:
+    id = 0
+    uploaded_by_id = 0
+    parsed_data = None
+    status = ""
+class FileStatus(str):
+    COMPLETED = 'completed'
+mock_user = types.ModuleType("app.models.user")
+class User: pass
+mock_user.User = User
+sys.modules.setdefault("app.models.user", mock_user)
+mock_parser = types.ModuleType("app.services.excel_parser")
+class ParsedData: pass
+class SheetInfo: pass
+class CellInfo: pass
+class DataType: TEXT="text"; NUMBER="number"
+class SheetType: PROFIT_LOSS="profit_loss"
+mock_parser.ParsedData=ParsedData
+mock_parser.SheetInfo=SheetInfo
+mock_parser.CellInfo=CellInfo
+mock_parser.DataType=DataType
+mock_parser.SheetType=SheetType
+sys.modules.setdefault("app.services.excel_parser", mock_parser)
+mock_file.UploadedFile = UploadedFile
+mock_file.FileStatus = FileStatus
+import os
+sys.modules.setdefault('app.models.file', mock_file)
+# Stub pandas which is heavy
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+
+import io
+import pytest
+from app.services import cloud_storage
+from app.services.dashboard_metrics import DashboardMetricsService
+
+
+@pytest.mark.asyncio
+async def test_cloud_storage_manager_filename_and_stats(tmp_path, monkeypatch):
+    monkeypatch.setenv('STORAGE_PROVIDER', 'local')
+    manager = cloud_storage.CloudStorageManager()
+    manager.storage_provider.storage_path = tmp_path
+    name = manager.generate_secure_filename('report.xlsx', user_id=1)
+    saved = await manager.upload_file(io.BytesIO(b"data"), name, user_id=1)
+    rel = os.path.relpath(saved, manager.storage_provider.storage_path)
+    assert await manager.file_exists(rel)
+    assert await manager.download_file(rel) == b"data"
+
+
+class DummyQuery:
+    def __init__(self, single=None, multiple=None):
+        self.single = single
+        self.multiple = multiple or []
+    def filter(self, *args, **kwargs):
+        return self
+    def order_by(self, *args, **kwargs):
+        return self
+    def first(self):
+        return self.single
+    def all(self):
+        return self.multiple
+
+class DummyDB:
+    def __init__(self, single=None, multiple=None):
+        self.single = single
+        self.multiple = multiple or []
+    def query(self, *args, **kwargs):
+        return DummyQuery(self.single, self.multiple)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_refresh_cache_variants():
+    file = types.SimpleNamespace(parsed_data='{}', uploaded_by_id=1, status='completed')
+    service = DashboardMetricsService(DummyDB(single=file))
+    result = await service.refresh_cache(user_id=1, file_id=1)
+    assert result['files_processed'] == 1
+    assert result['metrics_updated'] == 10
+
+    files = [types.SimpleNamespace(parsed_data='{}', uploaded_by_id=1, status='completed') for _ in range(2)]
+    service2 = DashboardMetricsService(DummyDB(multiple=files))
+    result2 = await service2.refresh_cache(user_id=1)
+    assert result2['files_processed'] == 2
+    assert result2['metrics_updated'] == 20
+
+    file_none = types.SimpleNamespace(parsed_data=None, uploaded_by_id=1, status='completed')
+    service3 = DashboardMetricsService(DummyDB(single=file_none))
+    result3 = await service3.refresh_cache(user_id=1, file_id=1)
+    assert result3['files_processed'] == 0
+    assert result3['metrics_updated'] == 0

--- a/lite_tests/test_config_permissions.py
+++ b/lite_tests/test_config_permissions.py
@@ -21,7 +21,9 @@ from app.core.permissions import (
 )
 
 
-def test_get_cors_origins_parsing():
+def test_get_cors_origins_parsing(monkeypatch):
+    """Ensure CORS list parsing works even if other env vars are set."""
+    monkeypatch.delenv("VIRUS_SCANNERS", raising=False)
     settings = Settings(BACKEND_CORS_ORIGINS="http://a.com,http://b.com")
     assert settings.get_cors_origins() == ["http://a.com", "http://b.com"]
     star = Settings(BACKEND_CORS_ORIGINS="*")


### PR DESCRIPTION
## Summary
- add `test_dashboard_metrics` checking demo metrics helpers
- cover `FileCleanupService.run_scheduled_cleanup`
- verify admin access in permission checker
- extend WebSocket manager tests for task progress and notifications
- add cloud manager and metrics refresh tests

## Testing
- `pytest backend/tests/test_websocket_manager.py -q --cov=app --cov-config=/dev/null --cov-fail-under=0`
- `pytest lite_tests/test_cloud_manager.py lite_tests/test_simple_module.py -q --cov=app --cov-config=/dev/null --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68850f1c2d008327bb1dca8bb9394732