### PR TITLE
Add missing unit tests for services

### DIFF
--- a/backend/tests/test_excel_parser.py
+++ b/backend/tests/test_excel_parser.py
@@ -1,0 +1,22 @@
+import pytest
+from app.services.excel_parser import ExcelParser, ParsedData, SheetInfo, DataType, SheetType, ValidationSummary
+
+def test_validate_data_no_sheets():
+    parser = ExcelParser()
+    data = ParsedData(file_name='f.xlsx', file_path='f.xlsx', file_size=10)
+    summary = parser._validate_data(data)
+    assert not summary.is_valid
+    assert summary.total_errors == 1
+    assert summary.errors[0].message.startswith("No worksheets")
+
+
+def test_export_to_dict_minimal():
+    parser = ExcelParser()
+    sheet = SheetInfo(name='S1', sheet_type=SheetType.PROFIT_LOSS, max_row=0, max_column=0)
+    data = ParsedData(file_name='f.xlsx', file_path='f.xlsx', file_size=10, sheets=[sheet])
+    summary = ValidationSummary(is_valid=True)
+    data.validation_summary = summary
+    result = parser.export_to_dict(data)
+    assert result['file_info']['name'] == 'f.xlsx'
+    assert result['sheets'][0]['name'] == 'S1'
+    assert result['validation']['is_valid']

--- a/backend/tests/test_parameter_detector.py
+++ b/backend/tests/test_parameter_detector.py
@@ -1,0 +1,16 @@
+from app.services.parameter_detector import ParameterDetector
+
+
+def test_detect_growth_patterns_handles_zero():
+    det = ParameterDetector()
+    data = [0, 0, 10]
+    result = det.detect_growth_patterns(data)
+    # Prev zero should skip division
+    assert result['average_growth_rate'] == 0
+    assert result['growth_rates'] == []
+
+
+def test_detect_growth_patterns_bad_input():
+    det = ParameterDetector()
+    result = det.detect_growth_patterns(['a', 'b'])
+    assert 'error' in result

--- a/backend/tests/test_partial_processor.py
+++ b/backend/tests/test_partial_processor.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from app.services.partial_processor import PartialProcessor
+
+
+def test_auto_fix_text_to_number():
+    pp = PartialProcessor()
+    assert pp._auto_fix_text_to_number(' 1,234 ') == 1234.0
+    assert pp._auto_fix_text_to_number('bad') is None
+
+
+def test_auto_fix_missing_headers():
+    pp = PartialProcessor()
+    sheet = SimpleNamespace(max_column=3)
+    headers = pp._auto_fix_missing_headers(sheet)
+    assert headers == ['Column_1', 'Column_2', 'Column_3']
+
+
+def test_auto_fix_formula_errors():
+    pp = PartialProcessor()
+    fixed = pp._auto_fix_formula_errors('=A1/B1 #DIV/0!')
+    assert '#DIV/0!' not in fixed
+    assert fixed.endswith('0')
+
+
+def test_auto_fix_date_format():
+    pp = PartialProcessor()
+    assert pp._auto_fix_date_format('2024-01-02').year == 2024
+    assert pp._auto_fix_date_format('not a date') is None

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock, patch
+from app.services.report_service import ReportService
+from app.models.report import ReportType
+
+
+def test_create_template_commits():
+    db = MagicMock()
+    with patch('app.services.report_service.PDFReportGenerator'), \
+         patch('app.services.report_service.ExcelExporter'), \
+         patch('app.services.report_service.DashboardMetricsService'), \
+         patch('app.services.report_service.ReportTemplate') as mock_model:
+        service = ReportService(db)
+        instance = mock_model.return_value
+        data = {'name': 'T1', 'report_type': ReportType.FINANCIAL_SUMMARY}
+        result = service.create_template(user_id=1, template_data=data)
+        db.add.assert_called_once_with(instance)
+        db.commit.assert_called()
+        db.refresh.assert_called_once_with(instance)
+        assert result is instance
+
+
+def test_get_template_returns_first():
+    db = MagicMock()
+    query = db.query.return_value
+    filter_q = query.filter.return_value
+    filter_q.first.return_value = 'x'
+    with patch('app.services.report_service.PDFReportGenerator'), \
+         patch('app.services.report_service.ExcelExporter'), \
+         patch('app.services.report_service.DashboardMetricsService'):
+        service = ReportService(db)
+        result = service.get_template(1, user_id=2)
+    assert result == 'x'
+    db.query.assert_called_once()


### PR DESCRIPTION
## Summary
- add new tests for ExcelParser validation and export helpers
- cover edge cases in ParameterDetector
- test PartialProcessor auto-fix utilities
- create basic ReportService unit tests

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68875efcce1883278ed75fed9bd798f0