### PR TITLE
Align chart components with design tokens

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 50",
     "lint:ci": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 100",
+    "format": "npx prettier --write \"src/**/*.{ts,tsx,css,scss,md}\"",
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/frontend/refactor-log.md
+++ b/frontend/refactor-log.md
@@ -9,9 +9,9 @@
   `ScenarioModeling`) and `BarChart` defaults
 - replaced hex colors in design tab components (`PLTab`, `CashFlowTab`, `SalesTab`, `ParametersTab`)
 - meta theme-color now reads from CSS variable
+- replaced hard-coded chart colors in `AnalyticsDashboard`, `LineChart`, and `PieChart`
 
 ### Pending
 - consolidate UI directories into one
 - unify theme providers
 - continue replacing hard-coded colors across legacy components
-

--- a/frontend/src/components/Analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/Analytics/AnalyticsDashboard.tsx
@@ -107,8 +107,15 @@ const AnalyticsDashboard: React.FC = () => {
     setTimePeriod(event.target.value as number);
   };
 
-  // Colors for charts
-  const chartColors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#0088fe'];
+  // Colors for charts pulled from design tokens
+  // DESIGN_FIX: replaced hard-coded hex colors with CSS variables
+  const chartColors = [
+    'var(--chart-1)',
+    'var(--chart-2)',
+    'var(--chart-3)',
+    'var(--chart-4)',
+    'var(--chart-5)',
+  ];
 
   // Default values to prevent undefined errors
   const overview = dashboardData?.overview || {
@@ -252,9 +259,27 @@ const AnalyticsDashboard: React.FC = () => {
                     <YAxis />
                     <Tooltip />
                     <Legend />
-                    <Line type="monotone" dataKey="total_files" stroke="#8884d8" name="Total Files" />
-                    <Line type="monotone" dataKey="completed_files" stroke="#82ca9d" name="Completed" />
-                    <Line type="monotone" dataKey="failed_files" stroke="#ffc658" name="Failed" />
+                    <Line
+                      type="monotone"
+                      dataKey="total_files"
+                      // DESIGN_FIX: use design token for chart color
+                      stroke="var(--chart-1)"
+                      name="Total Files"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="completed_files"
+                      // DESIGN_FIX: use design token for chart color
+                      stroke="var(--chart-2)"
+                      name="Completed"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="failed_files"
+                      // DESIGN_FIX: use design token for chart color
+                      stroke="var(--chart-3)"
+                      name="Failed"
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -275,7 +300,8 @@ const AnalyticsDashboard: React.FC = () => {
                       labelLine={false}
                       label={({ file_type, percentage }) => `${file_type} (${percentage}%)`}
                       outerRadius={80}
-                      fill="#8884d8"
+                      // DESIGN_FIX: use design token for default pie color
+                      fill="var(--chart-1)"
                       dataKey="count"
                     >
                       {fileTypeDistribution.map((_, index) => (
@@ -418,4 +444,4 @@ const AnalyticsDashboard: React.FC = () => {
   );
 };
 
-export default AnalyticsDashboard; 
+export default AnalyticsDashboard;

--- a/frontend/src/components/Charts/LineChart.tsx
+++ b/frontend/src/components/Charts/LineChart.tsx
@@ -54,15 +54,16 @@ interface LineChartProps {
   formatYAxisTick?: (value: number) => string;
 }
 
+// DESIGN_FIX: replace hard-coded palette with design system chart tokens
 const defaultColors = [
-  '#1976d2', // Primary blue
-  '#dc004e', // Secondary pink
-  '#2e7d32', // Success green
-  '#ed6c02', // Warning orange
-  '#9c27b0', // Purple
-  '#00695c', // Teal
-  '#c62828', // Red
-  '#5e35b1', // Deep purple
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
 ];
 
 export const LineChart: React.FC<LineChartProps> = ({
@@ -92,7 +93,7 @@ export const LineChart: React.FC<LineChartProps> = ({
     if (formatYAxisTick) {
       return formatYAxisTick(value);
     }
-    
+
     // Auto-format based on value size
     if (Math.abs(value) >= 1000000) {
       return `${currency}${(value / 1000000).toFixed(1)}M`;
@@ -130,24 +131,25 @@ export const LineChart: React.FC<LineChartProps> = ({
         {showGrid && (
           <CartesianGrid
             strokeDasharray="3 3"
-            stroke="#e0e0e0"
+            // DESIGN_FIX: use border token for grid color
+            stroke="var(--border)"
             opacity={0.5}
           />
         )}
-        
+
         <XAxis
           dataKey={xAxisKey}
           tick={{ fontSize: 12 }}
           tickFormatter={formatXAxis}
           label={xAxisLabel ? { value: xAxisLabel, position: 'insideBottom', offset: -10 } : undefined}
         />
-        
+
         <YAxis
           tick={{ fontSize: 12 }}
           tickFormatter={formatYAxis}
           label={yAxisLabel ? { value: yAxisLabel, angle: -90, position: 'insideLeft' } : undefined}
         />
-        
+
         <RechartsTooltip
           data-testid="tooltip"
           content={
@@ -158,7 +160,7 @@ export const LineChart: React.FC<LineChartProps> = ({
             />
           }
         />
-        
+
         {showLegend && (
           <Legend
             wrapperStyle={{
@@ -173,7 +175,8 @@ export const LineChart: React.FC<LineChartProps> = ({
           <ReferenceLine
             key={index}
             y={refLine.value}
-            stroke={refLine.color || '#666'}
+            // DESIGN_FIX: use muted foreground token for reference lines
+            stroke={refLine.color || 'var(--muted-foreground)'}
             strokeDasharray="5 5"
             label={{
               value: refLine.label || '',
@@ -198,7 +201,8 @@ export const LineChart: React.FC<LineChartProps> = ({
               r: 4,
               stroke: seriesItem.color,
               strokeWidth: 2,
-              fill: '#fff',
+              // DESIGN_FIX: replace hard-coded white with background token
+              fill: 'var(--background)',
             }}
             connectNulls={false}
           />
@@ -222,4 +226,4 @@ export const LineChart: React.FC<LineChartProps> = ({
   );
 };
 
-export default LineChart; 
+export default LineChart;

--- a/frontend/src/components/Charts/PieChart.tsx
+++ b/frontend/src/components/Charts/PieChart.tsx
@@ -38,17 +38,18 @@ interface PieChartProps {
   formatTooltip?: (value: number | string, name: string) => [string, string];
 }
 
+// DESIGN_FIX: use chart color tokens from design system
 const defaultColors = [
-  '#1976d2', // Primary blue
-  '#dc004e', // Secondary pink
-  '#2e7d32', // Success green
-  '#ed6c02', // Warning orange
-  '#9c27b0', // Purple
-  '#00695c', // Teal
-  '#c62828', // Red
-  '#5e35b1', // Deep purple
-  '#795548', // Brown
-  '#607d8b', // Blue grey
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-1)',
 ];
 
 export const PieChart: React.FC<PieChartProps> = ({
@@ -91,13 +92,13 @@ export const PieChart: React.FC<PieChartProps> = ({
 
   const renderCustomizedLabel = (entry: { value: number; name: string }) => {
     if (!showLabels) return null;
-    
+
     const percentage = ((entry.value / total) * 100).toFixed(1);
-    
+
     if (showPercentages) {
       return `${percentage}%`;
     }
-    
+
     return entry.name;
   };
 
@@ -147,7 +148,8 @@ export const PieChart: React.FC<PieChartProps> = ({
           label={renderCustomizedLabel}
           outerRadius={chartRadius}
           innerRadius={innerRadius}
-          fill="#8884d8"
+          // DESIGN_FIX: replace default pie color with design token
+          fill="var(--chart-1)"
           dataKey="value"
           stroke="none"
         >
@@ -155,9 +157,9 @@ export const PieChart: React.FC<PieChartProps> = ({
             <Cell key={`cell-${index}`} fill={entry.color} />
           ))}
         </Pie>
-        
+
         <Tooltip data-testid="tooltip" content={customTooltip} />
-        
+
         {showLegend && (
           <Legend
             wrapperStyle={{
@@ -186,7 +188,7 @@ export const PieChart: React.FC<PieChartProps> = ({
     >
       <Box sx={{ position: 'relative', height: '100%' }}>
         {chartContent}
-        
+
         {/* Center Label for Donut Charts */}
         {isDonut && centerLabel && (
           <Box
@@ -207,7 +209,7 @@ export const PieChart: React.FC<PieChartProps> = ({
                 lineHeight: 1,
               }}
             >
-              {typeof centerLabel.value === 'number' 
+              {typeof centerLabel.value === 'number'
                 ? formatCurrency(centerLabel.value)
                 : centerLabel.value
               }
@@ -229,4 +231,4 @@ export const PieChart: React.FC<PieChartProps> = ({
   );
 };
 
-export default PieChart; 
+export default PieChart;


### PR DESCRIPTION
## Summary
- update AnalyticsDashboard chart colors to use CSS variables
- use design tokens for default colors in LineChart and PieChart
- document progress in refactor log
- add `format` script for pre-commit

## Testing
- `pre-commit run --files frontend/refactor-log.md frontend/src/components/Analytics/AnalyticsDashboard.tsx frontend/src/components/Charts/LineChart.tsx frontend/src/components/Charts/PieChart.tsx frontend/package.json` *(with frontend hooks skipped)*
- `python run_tests.py --quick` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688916ea87448327bd6ed46307ec0152