### PR TITLE
Frontend design tokens refactor

### DIFF
--- a/frontend/refactor-log.md
+++ b/frontend/refactor-log.md
@@ -9,6 +9,8 @@
   `ScenarioModeling`) and `BarChart` defaults
 - replaced hex colors in design tab components (`PLTab`, `CashFlowTab`, `SalesTab`, `ParametersTab`)
 - meta theme-color now reads from CSS variable
+- replaced inline colors in `FileUploadDropzone` and `AnalyticsDashboard`
+- mapped sensitivity colors in `ParameterEditor` to design tokens
 
 ### Pending
 - consolidate UI directories into one

--- a/frontend/src/components/Analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/Analytics/AnalyticsDashboard.tsx
@@ -108,7 +108,14 @@ const AnalyticsDashboard: React.FC = () => {
   };
 
   // Colors for charts
-  const chartColors = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#0088fe'];
+  const chartColors = [
+    // DESIGN_FIX: use CSS variables for chart palette
+    'var(--chart-1)',
+    'var(--chart-2)',
+    'var(--chart-3)',
+    'var(--chart-4)',
+    'var(--chart-5)',
+  ];
 
   // Default values to prevent undefined errors
   const overview = dashboardData?.overview || {
@@ -252,9 +259,27 @@ const AnalyticsDashboard: React.FC = () => {
                     <YAxis />
                     <Tooltip />
                     <Legend />
-                    <Line type="monotone" dataKey="total_files" stroke="#8884d8" name="Total Files" />
-                    <Line type="monotone" dataKey="completed_files" stroke="#82ca9d" name="Completed" />
-                    <Line type="monotone" dataKey="failed_files" stroke="#ffc658" name="Failed" />
+                    <Line
+                      type="monotone"
+                      dataKey="total_files"
+                      // DESIGN_FIX: use chart color token
+                      stroke="var(--chart-1)"
+                      name="Total Files"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="completed_files"
+                      // DESIGN_FIX: use chart color token
+                      stroke="var(--chart-2)"
+                      name="Completed"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="failed_files"
+                      // DESIGN_FIX: use chart color token
+                      stroke="var(--chart-3)"
+                      name="Failed"
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               </CardContent>
@@ -275,7 +300,8 @@ const AnalyticsDashboard: React.FC = () => {
                       labelLine={false}
                       label={({ file_type, percentage }) => `${file_type} (${percentage}%)`}
                       outerRadius={80}
-                      fill="#8884d8"
+                      // DESIGN_FIX: use chart color token
+                      fill="var(--chart-1)"
                       dataKey="count"
                     >
                       {fileTypeDistribution.map((_, index) => (

--- a/frontend/src/components/FileUpload/FileUploadDropzone.tsx
+++ b/frontend/src/components/FileUpload/FileUploadDropzone.tsx
@@ -173,18 +173,19 @@ const FileUploadDropzone: React.FC<FileUploadDropzoneProps> = ({
   };
 
   const getDropzoneStyles = () => {
-    let borderColor = '#cccccc';
-    let backgroundColor = '#fafafa';
+    // DESIGN_FIX: replace hard-coded colors with design tokens
+    let borderColor = 'var(--border)';
+    let backgroundColor = 'var(--input-background)';
 
     if (isDragAccept) {
-      borderColor = '#4caf50';
-      backgroundColor = '#f1f8e9';
+      borderColor = 'var(--chart-2)';
+      backgroundColor = 'var(--muted)';
     } else if (isDragReject) {
-      borderColor = '#f44336';
-      backgroundColor = '#ffebee';
+      borderColor = 'var(--destructive)';
+      backgroundColor = 'var(--muted)';
     } else if (isDragActive) {
-      borderColor = '#2196f3';
-      backgroundColor = '#e3f2fd';
+      borderColor = 'var(--accent)';
+      backgroundColor = 'var(--muted)';
     }
 
     return {
@@ -192,7 +193,8 @@ const FileUploadDropzone: React.FC<FileUploadDropzoneProps> = ({
       backgroundColor,
       borderWidth: 2,
       borderStyle: 'dashed',
-      borderRadius: '8px',
+      // DESIGN_FIX: use radius token
+      borderRadius: 'var(--radius-lg)',
       padding: '40px 20px',
       textAlign: 'center' as const,
       cursor: isUploading ? 'not-allowed' : 'pointer',
@@ -233,7 +235,14 @@ const FileUploadDropzone: React.FC<FileUploadDropzoneProps> = ({
       <Paper elevation={1} sx={getDropzoneStyles()}>
         <div data-testid="dropzone" {...getRootProps()}>
           <input aria-label="file input" data-testid="file-input" {...getInputProps()} />
-          <CloudUpload sx={{ fontSize: 48, color: '#666', mb: 2 }} />
+          <CloudUpload
+            sx={{
+              fontSize: 48,
+              // DESIGN_FIX: use muted foreground token
+              color: 'var(--muted-foreground)',
+              mb: 2,
+            }}
+          />
           
           {isDragActive ? (
             isDragAccept ? (

--- a/frontend/src/components/Parameters/ParameterEditor.tsx
+++ b/frontend/src/components/Parameters/ParameterEditor.tsx
@@ -145,11 +145,21 @@ const ParameterEditor: React.FC<ParameterEditorProps> = ({
   // Get sensitivity color
   const getSensitivityColor = (level: string) => {
     switch (level) {
-      case 'critical': return '#f44336';
-      case 'high': return '#ff9800';
-      case 'medium': return '#2196f3';
-      case 'low': return '#4caf50';
-      default: return '#757575';
+      case 'critical':
+        // DESIGN_FIX: use destructive color token
+        return 'var(--destructive)';
+      case 'high':
+        // DESIGN_FIX: mapped to chart color token
+        return 'var(--chart-1)';
+      case 'medium':
+        // DESIGN_FIX: mapped to chart color token
+        return 'var(--chart-2)';
+      case 'low':
+        // DESIGN_FIX: mapped to chart color token
+        return 'var(--chart-3)';
+      default:
+        // DESIGN_FIX: fallback to muted foreground
+        return 'var(--muted-foreground)';
     }
   };
 
@@ -233,6 +243,7 @@ const ParameterEditor: React.FC<ParameterEditorProps> = ({
                 size="small"
                 label={parameter.sensitivity_level}
                 sx={{
+                  // DESIGN_FIX: use design token colors
                   backgroundColor: getSensitivityColor(parameter.sensitivity_level),
                   color: 'white',
                   fontSize: '0.7rem',
@@ -273,6 +284,7 @@ const ParameterEditor: React.FC<ParameterEditorProps> = ({
               size="small"
               label={parameter.sensitivity_level}
               sx={{
+                // DESIGN_FIX: use design token colors
                 backgroundColor: getSensitivityColor(parameter.sensitivity_level),
                 color: 'white',
               }}


### PR DESCRIPTION
## Summary
- replace hex colors with design tokens in ParameterEditor
- refactor FileUploadDropzone styles to use design variables
- update AnalyticsDashboard chart colors to use design tokens
- log new refactors in `refactor-log.md`

## Testing
- `npm run lint`
- `npm run test` *(fails: Dynamic require of "react/jsx-runtime" is not supported)*
- `python run_tests.py --quick` *(fails: flake8 missing)*
- `pre-commit run --files frontend/refactor-log.md frontend/src/components/Analytics/AnalyticsDashboard.tsx frontend/src/components/FileUpload/FileUploadDropzone.tsx frontend/src/components/Parameters/ParameterEditor.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892cba122083278c3fc3dc9c01c334