### PR TITLE
Unify theme provider

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "test:a11y": "vitest run src/test/a11y.test.tsx",
     "test:all": "npm run test:unit && npm run test:integration && npm run e2e",
     "test:quick": "vitest run --changed",
-    "test:debug": "vitest --inspect-brk --no-coverage"
+    "test:debug": "vitest --inspect-brk --no-coverage",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.22.5",

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,13 +1,10 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { ThemeProvider as MuiThemeProvider, Theme } from '@mui/material/styles';
-import { CssBaseline } from '@mui/material';
-import { lightTheme, darkTheme } from '../theme';
+
 
 type ThemeMode = 'light' | 'dark' | 'system';
 
 interface ThemeContextType {
   mode: ThemeMode;
-  currentTheme: Theme;
   toggleTheme: () => void;
   setThemeMode: (mode: ThemeMode) => void;
   isDarkMode: boolean;
@@ -51,14 +48,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [, setSystemTheme] = useState<'light' | 'dark'>(getSystemTheme);
 
   const effectiveTheme = getEffectiveTheme(mode);
-  const currentTheme = effectiveTheme === 'dark' ? darkTheme : lightTheme;
   const isDarkMode = effectiveTheme === 'dark';
 
   // Listen for system theme changes
   useEffect(() => {
     if (typeof window !== 'undefined' && window.matchMedia) {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      
+
       const handleChange = (e: MediaQueryListEvent) => {
         setSystemTheme(e.matches ? 'dark' : 'light');
       };
@@ -79,9 +75,9 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const root = document.documentElement;
-      root.classList.remove('light-theme', 'dark-theme');
-      root.classList.add(`${effectiveTheme}-theme`);
-      
+      root.classList.remove('light', 'dark');
+      root.classList.add(effectiveTheme);
+
       // Update meta theme-color for mobile browsers
       const metaThemeColor = document.querySelector('meta[name="theme-color"]');
       if (metaThemeColor) {
@@ -113,19 +109,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
 
   const value: ThemeContextType = {
     mode,
-    currentTheme,
     toggleTheme,
     setThemeMode,
     isDarkMode,
   };
 
   return (
-    <ThemeContext.Provider value={value}>
-      <MuiThemeProvider theme={currentTheme}>
-        <CssBaseline />
-        {children}
-      </MuiThemeProvider>
-    </ThemeContext.Provider>
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
   );
 };
 
@@ -137,4 +127,4 @@ export const useTheme = (): ThemeContextType => {
   return context;
 };
 
-export default ThemeProvider; 
+export default ThemeProvider;

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -2,8 +2,6 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider as CustomThemeProvider } from '../contexts/ThemeContext';
 import { vi } from 'vitest';
 
@@ -32,20 +30,6 @@ vi.mock('../contexts/AuthContext', async () => {
       isAuthenticated: false,
     }),
   };
-});
-import { createTheme } from '@mui/material/styles';
-
-// Create a test theme
-const testTheme = createTheme({
-  palette: {
-    mode: 'light',
-    primary: {
-      main: '#1976d2',
-    },
-    secondary: {
-      main: '#dc004e',
-    },
-  },
 });
 
 // Create a new QueryClient for each test
@@ -96,12 +80,7 @@ const AllTheProviders: React.FC<ProviderProps> = ({
 }) => {
   const content = (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={testTheme}>
-        <CustomThemeProvider>
-          <CssBaseline />
-          {children}
-        </CustomThemeProvider>
-      </ThemeProvider>
+      <CustomThemeProvider>{children}</CustomThemeProvider>
     </QueryClientProvider>
   );
 


### PR DESCRIPTION
## Summary
- replace MUI based ThemeContext with CSS variable implementation
- drop MUI theme usage in test helpers
- add `format` script for frontend

## Testing
- `pre-commit run --files frontend/src/contexts/ThemeContext.tsx frontend/src/test/test-utils.tsx frontend/package.json` *(with frontend-format skipped)*
- `python run_tests.py --quick` *(fails: ScrollArea > renders scrollbar)*

------
https://chatgpt.com/codex/tasks/task_e_688931b6a510832798f07eb63db37763