### PR TITLE
Fix index creation conflict in Alembic migration

### DIFF
--- a/backend/alembic/versions/006_add_advanced_indexes.py
+++ b/backend/alembic/versions/006_add_advanced_indexes.py
@@ -7,6 +7,7 @@ Create Date: 2024-12-20 11:00:00.000000
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision = "006"
@@ -17,7 +18,12 @@ depends_on = None
 
 def upgrade():
     # Advanced indexes for users table
-    op.create_index("ix_users_last_login", "users", ["last_login"], unique=False)
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_indexes = [ix["name"] for ix in inspector.get_indexes("users")]
+
+    if "ix_users_last_login" not in existing_indexes:
+        op.create_index("ix_users_last_login", "users", ["last_login"], unique=False)
     op.create_index(
         "ix_users_created_date", "users", [sa.text("DATE(created_at)")], unique=False
     )


### PR DESCRIPTION
## Summary
- ensure `ix_users_last_login` index isn't recreated if it already exists

## Testing
- `pre-commit run --files backend/alembic/versions/006_add_advanced_indexes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ce497078c832784a073a8df565780