### PR TITLE
Fix index migration for Railway

### DIFF
--- a/backend/alembic/versions/006_add_advanced_indexes.py
+++ b/backend/alembic/versions/006_add_advanced_indexes.py
@@ -7,7 +7,7 @@ Create Date: 2024-12-20 11:00:00.000000
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import inspect
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision = "006"
@@ -19,14 +19,13 @@ depends_on = None
 def upgrade():
     # Advanced indexes for users table
     conn = op.get_bind()
-    inspector = inspect(conn)
-    existing_indexes = [ix["name"] for ix in inspector.get_indexes("users")]
 
-    if "ix_users_last_login" not in existing_indexes:
+    if not conn.execute(text("SELECT to_regclass('ix_users_last_login')")).scalar():
         op.create_index("ix_users_last_login", "users", ["last_login"], unique=False)
-    op.create_index(
-        "ix_users_created_date", "users", [sa.text("DATE(created_at)")], unique=False
-    )
+
+    if not conn.execute(text("SELECT to_regclass('ix_users_created_date')")).scalar():
+        op.execute("CREATE INDEX ix_users_created_date ON users (DATE(created_at))")
+
     op.create_index(
         "ix_users_active_verified", "users", ["is_active", "is_verified"], unique=False
     )

--- a/backend/docs/DATABASE_SCHEMA.md
+++ b/backend/docs/DATABASE_SCHEMA.md
@@ -678,5 +678,8 @@ REINDEX INDEX CONCURRENTLY ix_timeseries_scenario_type_date;
 2. Test migrations on copy of production data
 3. Plan rollback strategy
 4. Update documentation
+5. When deploying on Railway, ensure index creation is idempotent. Use a
+   `to_regclass` existence check or drop conflicting indexes prior to
+   running the migration to avoid repeated deploy failures.
 
 This comprehensive schema provides a robust foundation for the FinVision platform's financial modeling and analysis capabilities.


### PR DESCRIPTION
## Summary
- make advanced indexes migration idempotent
- document Railway index creation strategy

## Testing
- `pre-commit run --files backend/alembic/versions/006_add_advanced_indexes.py backend/docs/DATABASE_SCHEMA.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce7d268c88327b8e1ec1777bea426