### PR TITLE
Fix parameter group foreign key type mismatch

### DIFF
--- a/backend/alembic/versions/93a0bb4bdb0b_add_parameter_groups_and_history.py
+++ b/backend/alembic/versions/93a0bb4bdb0b_add_parameter_groups_and_history.py
@@ -5,13 +5,12 @@ Revises: 008
 Create Date: 2025-08-02 15:40:57.310820
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '93a0bb4bdb0b'
-down_revision = '008'
+revision = "93a0bb4bdb0b"
+down_revision = "008"
 branch_labels = None
 depends_on = None
 
@@ -19,57 +18,83 @@ depends_on = None
 def upgrade() -> None:
     # Create parameter_groups table
     op.create_table(
-        'parameter_groups',
-        sa.Column('id', sa.String(length=50), primary_key=True),
-        sa.Column('model_id', sa.String(length=50), sa.ForeignKey('uploaded_files.id'), nullable=False),
-        sa.Column('name', sa.String(length=255), nullable=False),
-        sa.Column('description', sa.Text, nullable=True),
-        sa.Column('display_order', sa.Integer, nullable=True),
-        sa.Column('is_expanded', sa.Boolean, default=True),
-        sa.Column('created_at', sa.DateTime, default=sa.func.now()),
-        sa.Column('updated_at', sa.DateTime, default=sa.func.now(), onupdate=sa.func.now()),
+        "parameter_groups",
+        sa.Column("id", sa.String(length=50), primary_key=True),
+        sa.Column(
+            "model_id", sa.Integer, sa.ForeignKey("uploaded_files.id"), nullable=False
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("display_order", sa.Integer, nullable=True),
+        sa.Column("is_expanded", sa.Boolean, default=True),
+        sa.Column("created_at", sa.DateTime, default=sa.func.now()),
+        sa.Column(
+            "updated_at", sa.DateTime, default=sa.func.now(), onupdate=sa.func.now()
+        ),
     )
-    
+
     # Create parameter_history table
     op.create_table(
-        'parameter_history',
-        sa.Column('id', sa.String(length=50), primary_key=True),
-        sa.Column('parameter_id', sa.Integer, sa.ForeignKey('parameters.id'), nullable=False),
-        sa.Column('old_value', sa.Numeric(precision=15, scale=6), nullable=True),
-        sa.Column('new_value', sa.Numeric(precision=15, scale=6), nullable=False),
-        sa.Column('changed_by', sa.Integer, sa.ForeignKey('users.id'), nullable=False),
-        sa.Column('changed_at', sa.DateTime, default=sa.func.now()),
-        sa.Column('change_reason', sa.String(length=255), nullable=True),
+        "parameter_history",
+        sa.Column("id", sa.String(length=50), primary_key=True),
+        sa.Column(
+            "parameter_id", sa.Integer, sa.ForeignKey("parameters.id"), nullable=False
+        ),
+        sa.Column("old_value", sa.Numeric(precision=15, scale=6), nullable=True),
+        sa.Column("new_value", sa.Numeric(precision=15, scale=6), nullable=False),
+        sa.Column("changed_by", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("changed_at", sa.DateTime, default=sa.func.now()),
+        sa.Column("change_reason", sa.String(length=255), nullable=True),
     )
-    
+
     # Add group_id to parameters table
-    op.add_column('parameters', sa.Column('group_id', sa.String(length=50), sa.ForeignKey('parameter_groups.id'), nullable=True))
-    
+    op.add_column(
+        "parameters",
+        sa.Column(
+            "group_id",
+            sa.String(length=50),
+            sa.ForeignKey("parameter_groups.id"),
+            nullable=True,
+        ),
+    )
+
     # Add control type and UI fields to parameters
-    op.add_column('parameters', sa.Column('control_type', sa.String(length=50), default='input'))
-    op.add_column('parameters', sa.Column('step_size', sa.Numeric(precision=15, scale=6), nullable=True))
-    op.add_column('parameters', sa.Column('display_format', sa.String(length=50), default='number'))
-    
+    op.add_column(
+        "parameters", sa.Column("control_type", sa.String(length=50), default="input")
+    )
+    op.add_column(
+        "parameters",
+        sa.Column("step_size", sa.Numeric(precision=15, scale=6), nullable=True),
+    )
+    op.add_column(
+        "parameters",
+        sa.Column("display_format", sa.String(length=50), default="number"),
+    )
+
     # Create indexes
-    op.create_index('ix_parameter_groups_model_id', 'parameter_groups', ['model_id'])
-    op.create_index('ix_parameter_history_parameter_id', 'parameter_history', ['parameter_id'])
-    op.create_index('ix_parameter_history_changed_at', 'parameter_history', ['changed_at'])
-    op.create_index('ix_parameters_group_id', 'parameters', ['group_id'])
+    op.create_index("ix_parameter_groups_model_id", "parameter_groups", ["model_id"])
+    op.create_index(
+        "ix_parameter_history_parameter_id", "parameter_history", ["parameter_id"]
+    )
+    op.create_index(
+        "ix_parameter_history_changed_at", "parameter_history", ["changed_at"]
+    )
+    op.create_index("ix_parameters_group_id", "parameters", ["group_id"])
 
 
 def downgrade() -> None:
     # Remove indexes
-    op.drop_index('ix_parameters_group_id', 'parameters')
-    op.drop_index('ix_parameter_history_changed_at', 'parameter_history')
-    op.drop_index('ix_parameter_history_parameter_id', 'parameter_history')
-    op.drop_index('ix_parameter_groups_model_id', 'parameter_groups')
-    
+    op.drop_index("ix_parameters_group_id", "parameters")
+    op.drop_index("ix_parameter_history_changed_at", "parameter_history")
+    op.drop_index("ix_parameter_history_parameter_id", "parameter_history")
+    op.drop_index("ix_parameter_groups_model_id", "parameter_groups")
+
     # Remove columns from parameters
-    op.drop_column('parameters', 'display_format')
-    op.drop_column('parameters', 'step_size')
-    op.drop_column('parameters', 'control_type')
-    op.drop_column('parameters', 'group_id')
-    
+    op.drop_column("parameters", "display_format")
+    op.drop_column("parameters", "step_size")
+    op.drop_column("parameters", "control_type")
+    op.drop_column("parameters", "group_id")
+
     # Drop tables
-    op.drop_table('parameter_history')
-    op.drop_table('parameter_groups') 
+    op.drop_table("parameter_history")
+    op.drop_table("parameter_groups")

--- a/backend/app/models/parameter.py
+++ b/backend/app/models/parameter.py
@@ -1,21 +1,19 @@
-from typing import Dict, List, Any, Optional, Union
 from datetime import datetime
 from enum import Enum
-from sqlalchemy import (
-    Column,
-    Integer,
-    String,
-    Float,
-    DateTime,
-    Text,
-    Boolean,
-    ForeignKey,
-    JSON,
-)
-from sqlalchemy.orm import relationship, synonym
-from sqlalchemy.ext.declarative import declarative_base
 
 from app.models.base import Base
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship, synonym
 
 
 class ParameterType(str, Enum):
@@ -115,8 +113,10 @@ class Parameter(Base):
     # UI Configuration - enhanced for Task 04
     control_type = Column(String(50), default="input")  # slider, input, dropdown
     step_size = Column(Float, nullable=True)
-    display_format = Column(String(50), default="number")  # number, percentage, currency
-    
+    display_format = Column(
+        String(50), default="number"
+    )  # number, percentage, currency
+
     # Grouping
     group_id = Column(String(50), ForeignKey("parameter_groups.id"), nullable=True)
 
@@ -156,20 +156,20 @@ class Parameter(Base):
 
 class ParameterGroup(Base):
     """Model for grouping parameters by category or function."""
-    
+
     __tablename__ = "parameter_groups"
-    
+
     id = Column(String(50), primary_key=True)
-    model_id = Column(String(50), ForeignKey("uploaded_files.id"), nullable=False)
+    model_id = Column(Integer, ForeignKey("uploaded_files.id"), nullable=False)
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=True)
     display_order = Column(Integer, nullable=True)
     is_expanded = Column(Boolean, default=True)
-    
+
     # Metadata
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-    
+
     # Relationships
     parameters = relationship("Parameter", back_populates="group")
     model = relationship("UploadedFile")
@@ -177,9 +177,9 @@ class ParameterGroup(Base):
 
 class ParameterHistory(Base):
     """Model for tracking parameter value changes."""
-    
+
     __tablename__ = "parameter_history"
-    
+
     id = Column(String(50), primary_key=True)
     parameter_id = Column(Integer, ForeignKey("parameters.id"), nullable=False)
     old_value = Column(Float, nullable=True)
@@ -187,7 +187,7 @@ class ParameterHistory(Base):
     changed_by = Column(Integer, ForeignKey("users.id"), nullable=False)
     changed_at = Column(DateTime, default=datetime.utcnow)
     change_reason = Column(String(255), nullable=True)
-    
+
     # Relationships
     parameter = relationship("Parameter", back_populates="history")
     user = relationship("User")


### PR DESCRIPTION
## Summary
- align `parameter_groups.model_id` type with `uploaded_files.id`
- update ParameterGroup ORM mapping accordingly

## Testing
- `pre-commit run --files backend/alembic/versions/93a0bb4bdb0b_add_parameter_groups_and_history.py backend/app/models/parameter.py`
- `pytest` *(fails: NameError: name 'router' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e39a9f06c83278b20ce14e179e35a