### PR TITLE
fix: add networkx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,9 @@ weasyprint==61.2
 Pillow>=10.1.0
 matplotlib>=3.8.0
 
+# Graph algorithms
+networkx>=3.2.1
+
 # Background tasks
 celery==5.3.4
 redis==5.0.1


### PR DESCRIPTION
## Summary
- include networkx to support recalculation engine

## Testing
- `python run_tests.py --quick` (fails: can't open file)
- `pytest` (fails: async def functions are not natively supported)


------
https://chatgpt.com/codex/tasks/task_e_688e449e37fc832785b759398facec23