### PR TITLE
chore(storybook): remove redundant dark theme config

### DIFF
--- a/frontend/.storybook/manager.ts
+++ b/frontend/.storybook/manager.ts
@@ -1,16 +1,6 @@
 import { addons } from '@storybook/manager-api';
 import { create } from '@storybook/theming/create';
 
-addons.setConfig({
-  theme: create({
-    base: 'dark',
-    brandTitle: 'FinVision UI',
-  }),
-});
-
-import { addons } from '@storybook/manager-api';
-import { create } from '@storybook/theming/create';
-
 const theme = create({
   base: 'light',
   brandTitle: 'FinVision Design System',


### PR DESCRIPTION
## Summary
- drop dark theme config from Storybook manager
- consolidate imports and use design system light theme

## Testing
- `pnpm test:minimal:ci` *(fails: Command failed with exit code 1)*
- `pnpm lint:ci` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68975145b2b8832793b04c334283a641