### PR TITLE
chore: consolidate Storybook story sorting

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -110,19 +110,6 @@ const config: StorybookConfig = {
       }
     </style>
   `,
-  // Improved story organization
-  storySort: {
-    order: [
-      'Docs',
-      'Getting Started',
-      'Design System',
-      ['Overview', 'Foundations', 'Tokens', 'Templates', '*'],
-      'Components',
-      ['Auth', 'Dashboard', 'Parameters', 'Scenarios', 'Charts', 'FileUpload', '*'],
-      'Pages',
-      '*'
-    ],
-  },
 };
 
 export default config;

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -32,7 +32,16 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['Docs', 'Design Tokens', ['Colors', 'Typography', 'Spacing', 'Shadows'], 'Components', ['Atoms', 'Molecules', 'Organisms'], 'Pages', 'Flows'],
+        order: [
+          'Docs',
+          'Getting Started',
+          'Design System',
+          ['Overview', 'Foundations', 'Tokens', 'Templates', '*'],
+          'Components',
+          ['Auth', 'Dashboard', 'Parameters', 'Scenarios', 'Charts', 'FileUpload', '*'],
+          'Pages',
+          '*',
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary
- consolidate story sort config into preview.tsx
- remove duplicate story sort from main.ts

## Testing
- `pre-commit run --files frontend/.storybook/preview.tsx frontend/.storybook/main.ts` *(fails: missing `lint` and `format` scripts)*
- `pnpm lint:ci` *(fails: 1 error, 74 warnings)*
- `pnpm test:minimal:ci` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68975151cdf08327b2bf6f0c390b8ad6