### PR TITLE
Use typed query params for admin activity list

### DIFF
--- a/backend/app/api/v1/endpoints/admin.py
+++ b/backend/app/api/v1/endpoints/admin.py
@@ -27,7 +27,7 @@ from app.services.database_monitor import get_db_monitor
 from app.services.file_service import FileService
 from app.services.system_log_service import SystemLogService
 from app.services.maintenance_service import MaintenanceService
-from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import (
     JSONResponse,
     PlainTextResponse,
@@ -126,9 +126,10 @@ class BulkUserActionRequest(BaseModel):
     action: str
 
 
-@router.get("/users/activity-list")
+@router.get("/users/activity-list", response_model=list[UserActivityResponse])
 async def get_user_activity(
-    request: Request,
+    limit: int = Query(50, ge=1, le=1000),
+    active_only: bool = Query(False),
     current_user: User = Depends(require_permissions(Permission.ADMIN_READ)),
     db: Session = Depends(get_db),
 ):
@@ -138,23 +139,10 @@ async def get_user_activity(
     """
     try:
         query = db.query(User)
-        # Parse params defensively
-        qp = request.query_params
-        limit_raw = qp.get("limit")
-        try:
-            limit_val = int(limit_raw) if limit_raw is not None else 50
-        except Exception:
-            limit_val = 50
-        active_raw = qp.get("active_only")
-        active_only_bool = (
-            str(active_raw).lower() in {"true", "1", "yes"}
-            if active_raw is not None
-            else False
-        )
-        if active_only_bool:
+        if active_only:
             query = query.filter(User.is_active.is_(True))
 
-        users = query.order_by(desc(User.created_at)).limit(limit_val).all()
+        users = query.order_by(desc(User.created_at)).limit(limit).all()
 
         activity_data: List[Dict[str, Any]] = []
         for user in users:

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -274,11 +274,9 @@ def test_security_audit_and_data_integrity(client: TestClient):
 def test_user_activity_list_endpoint(client: TestClient):
     r = client.get(
         "/api/v1/admin/users/activity-list",
-        params={"limit": "2", "active_only": "true"},
+        params={"limit": 2, "active_only": True},
     )
-    assert r.status_code in (200, 422)
-    if r.status_code != 200:
-        pytest.skip("Activity list query param parsing differs in this build")
+    assert r.status_code == 200
     data = r.json()
     assert isinstance(data, list)
     assert len(data) <= 2


### PR DESCRIPTION
## Summary
- replace manual request parsing with explicit FastAPI parameters for `get_user_activity`
- validate `limit` and `active_only` via query params
- update activity list tests for new parameter handling

## Testing
- `pytest` *(fails: AssertionError: assert 404 == 200; ModuleNotFoundError: No module named 'app.db')*

------
https://chatgpt.com/codex/tasks/task_e_68975e96ee308327a173ef2939335047