### PR TITLE
feat: add async task processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ FinVision is a comprehensive web-based financial modeling and analysis platform 
 - **Database**: PostgreSQL 15
 - **Cache/Queue**: Redis 7
 
+## ⏱️ Background Job Workflow
+
+Long-running calculations run asynchronously using Celery. For example, to
+calculate the comprehensive financial model:
+
+1. `POST /api/v1/lean-financial/calculate/comprehensive` – returns a `task_id`
+   instead of the immediate result.
+2. `GET /api/v1/tasks/{task_id}` – check task status and retrieve results when
+   completed.
+
 ## 🛠️ Development Setup
 
 ### Prerequisites

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,18 +1,19 @@
-from fastapi import APIRouter
 from app.api.v1.endpoints import (
-    auth,
-    mfa,
-    oauth,
-    webauthn,
     admin,
-    files,
+    auth,
     dashboard,
+    files,
+    lean_financial,
+    mfa,
+    notifications,
+    oauth,
     parameters,
     scenarios,
     statements,
-    lean_financial,
-    notifications,
+    tasks,
+    webauthn,
 )
+from fastapi import APIRouter
 
 api_router = APIRouter()
 
@@ -61,6 +62,9 @@ api_router.include_router(
 api_router.include_router(
     notifications.router, prefix="/notifications", tags=["notifications"]
 )
+
+# Include task status routes
+api_router.include_router(tasks.router, prefix="/tasks", tags=["tasks"])
 
 
 @api_router.get("/")

--- a/backend/app/api/v1/endpoints/tasks.py
+++ b/backend/app/api/v1/endpoints/tasks.py
@@ -1,0 +1,16 @@
+from app.core.celery_app import celery_app
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/{task_id}")
+def get_task_status(task_id: str):
+    """Return status and result of a background task."""
+    task = celery_app.AsyncResult(task_id)
+    response = {"task_id": task_id, "status": task.status}
+    if task.successful():
+        response["result"] = task.result
+    elif task.failed():
+        response["error"] = str(task.result)
+    return response

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -1,6 +1,6 @@
-from celery import Celery
 import redis
 from app.core.config import settings
+from celery import Celery
 
 # Create Celery app
 celery_app = Celery(
@@ -12,6 +12,7 @@ celery_app = Celery(
         "app.tasks.notifications",
         "app.tasks.scheduled_tasks",
         "app.tasks.maintenance",
+        "app.tasks.lean_financial",
     ],
 )
 
@@ -48,6 +49,7 @@ celery_app.conf.update(
         "app.tasks.notifications.*": {"queue": "notifications"},
         "app.tasks.scheduled_tasks.*": {"queue": "scheduled"},
         "app.tasks.maintenance.*": {"queue": "maintenance"},
+        "app.tasks.lean_financial.*": {"queue": "lean_financial"},
     },
     # Define queues
     task_queues={
@@ -74,6 +76,10 @@ celery_app.conf.update(
         "maintenance": {
             "exchange": "maintenance",
             "routing_key": "maintenance",
+        },
+        "lean_financial": {
+            "exchange": "lean_financial",
+            "routing_key": "lean_financial",
         },
     },
     # Monitoring

--- a/backend/app/tasks/lean_financial.py
+++ b/backend/app/tasks/lean_financial.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List, Optional
+
+from app.core.celery_app import celery_app
+from app.models.base import SessionLocal
+from app.services.lean_financial_engine import LeanFinancialEngine
+from app.services.lean_parameter_manager import LeanParameterManager
+from celery import Task
+from sqlalchemy.orm import Session
+
+
+class DatabaseTask(Task):
+    """Base task with database session management."""
+
+    def __call__(self, *args, **kwargs):
+        with SessionLocal() as db:
+            return self.run_with_db(db, *args, **kwargs)
+
+    def run_with_db(self, db: Session, *args, **kwargs):
+        raise NotImplementedError
+
+
+@celery_app.task(
+    bind=True,
+    base=DatabaseTask,
+    name="app.tasks.lean_financial.calculate_comprehensive_model",
+)
+def calculate_comprehensive_model_task(
+    self,
+    db: Session,
+    parameters: Dict[str, float],
+    base_revenue: float = 1_000_000,
+) -> Dict[str, Any]:
+    """Calculate the comprehensive financial model in the background."""
+    param_manager = LeanParameterManager(db)
+    engine = LeanFinancialEngine(db)
+
+    is_valid, errors = param_manager.validate_parameters(parameters)
+    if not is_valid:
+        return {"success": False, "errors": errors}
+
+    core_parameters = param_manager.create_core_parameters_from_dict(parameters)
+    result = engine.calculate_comprehensive_model(core_parameters, base_revenue)
+
+    return {
+        "success": True,
+        "data": {
+            "profit_loss": result["profit_loss"].__dict__,
+            "balance_sheet": result["balance_sheet"].__dict__,
+            "cash_flow": result["cash_flow"].__dict__,
+            "dcf_valuation": result["dcf_valuation"].__dict__,
+            "parameters": result["parameters"].__dict__,
+            "calculation_timestamp": result["calculation_timestamp"],
+            "model_version": result["model_version"],
+        },
+    }
+
+
+@celery_app.task(
+    bind=True,
+    base=DatabaseTask,
+    name="app.tasks.lean_financial.create_sensitivity_analysis",
+)
+def create_sensitivity_analysis_task(
+    self,
+    db: Session,
+    base_parameters: Dict[str, float],
+    sensitivity_parameters: Optional[List[str]] = None,
+    variation_percent: float = 0.20,
+) -> Dict[str, Any]:
+    """Generate a sensitivity analysis in the background."""
+    param_manager = LeanParameterManager(db)
+    analysis = param_manager.create_sensitivity_analysis(
+        base_parameters,
+        sensitivity_parameters,
+        variation_percent,
+    )
+    return {"success": True, "data": analysis}


### PR DESCRIPTION
## Summary
- add Celery tasks for comprehensive model and sensitivity analysis
- expose task status endpoint and queue heavy Lean Financial calculations
- document async workflow in README

## Testing
- `pre-commit run --files README.md backend/app/api/v1/api.py backend/app/api/v1/endpoints/lean_financial.py backend/app/api/v1/endpoints/tasks.py backend/app/core/celery_app.py backend/app/tasks/lean_financial.py`
- `python run_tests.py --quick` *(fails: file not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68975e9c8bd88327a7a7ebbeb647e237