### PR TITLE
feat: add paginated user management

### DIFF
--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -53,7 +53,8 @@ def test_user_crud_and_roles(client: TestClient):
     )
     assert r.status_code == 200
     data = r.json()
-    assert {"items", "skip", "limit", "total"} <= data.keys()
+    assert {"items", "pagination"} <= data.keys()
+    assert {"skip", "limit", "total"} <= data["pagination"].keys()
 
     # Get user by id
     r = client.get(f"/api/v1/admin/users/{user_id}")

--- a/frontend/src/components/Admin/UserManagement.tsx
+++ b/frontend/src/components/Admin/UserManagement.tsx
@@ -120,58 +120,45 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
   const [roleUser, setRoleUser] = useState<UserWithRoles | null>(null);
   const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
 
+  const [page, setPage] = useState(0);
+  const rowsPerPage = 20;
+  const [total, setTotal] = useState(0);
+
   // Load users
   const loadUsers = async () => {
     try {
       setLoading(true);
-      const resp = await AdminApiService.listUsers(0, 200, true);
+      const params: any = {};
+      if (searchTerm) params.search = searchTerm;
+      if (statusFilter === 'active') params.is_active = true;
+      else if (statusFilter === 'inactive') params.is_active = false;
+      else if (statusFilter === 'verified') params.is_verified = true;
+      else if (statusFilter === 'unverified') params.is_verified = false;
+      if (roleFilter === 'admin') params.is_admin = true;
+
+      const resp = await AdminApiService.listUsers(
+        page * rowsPerPage,
+        rowsPerPage,
+        true,
+        params
+      );
       const env = resp as any;
-      const list = (env?.items as UserWithRoles[]) || (resp as UserWithRoles[]);
+      let list = (env?.items as UserWithRoles[]) || (resp as UserWithRoles[]);
+      if (roleFilter !== 'all' && roleFilter !== 'admin') {
+        list = list.filter(user => user.roles.includes(roleFilter));
+      }
       setUsers(list);
       setFilteredUsers(list);
+      setTotal(env?.pagination?.total ?? list.length);
     } catch (error) {
       toast.error('Failed to load users');
     } finally {
       setLoading(false);
     }
   };
-
-  // Filter users based on search and filters
   useEffect(() => {
-    let filtered = users;
-
-    // Search filter
-    if (searchTerm) {
-      filtered = filtered.filter(
-        user =>
-          user.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          user.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          `${user.first_name} ${user.last_name}`
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())
-      );
-    }
-
-    // Status filter
-    if (statusFilter !== 'all') {
-      if (statusFilter === 'active') {
-        filtered = filtered.filter(user => user.is_active);
-      } else if (statusFilter === 'inactive') {
-        filtered = filtered.filter(user => !user.is_active);
-      } else if (statusFilter === 'verified') {
-        filtered = filtered.filter(user => user.is_verified);
-      } else if (statusFilter === 'unverified') {
-        filtered = filtered.filter(user => !user.is_verified);
-      }
-    }
-
-    // Role filter
-    if (roleFilter !== 'all') {
-      filtered = filtered.filter(user => user.roles.includes(roleFilter));
-    }
-
-    setFilteredUsers(filtered);
-  }, [users, searchTerm, statusFilter, roleFilter]);
+    loadUsers();
+  }, [page, searchTerm, statusFilter, roleFilter]);
 
   // Handle user selection
   const handleUserSelection = (userId: number, checked: boolean) => {
@@ -426,16 +413,16 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-blue-600">
-              {users.length}
+              {total}
             </div>
             <div className="flex items-center mt-2">
               <div className="flex-1 bg-gray-200 rounded-full h-1.5">
                 <div
                   className="bg-blue-500 h-1.5 rounded-full"
                   style={{
-                    width: `${users.length > 0
+                    width: `${total > 0
                       ? (users.filter(u => u.is_active).length /
-                        users.length) *
+                        total) *
                       100
                       : 0
                       }%`,
@@ -443,10 +430,9 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
                 ></div>
               </div>
               <span className="text-xs text-muted-foreground ml-2">
-                {users.length > 0
+                {total > 0
                   ? Math.round(
-                    (users.filter(u => u.is_active).length / users.length) *
-                    100
+                    (users.filter(u => u.is_active).length / total) * 100
                   )
                   : 0}
                 % active
@@ -524,14 +510,23 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
                 <Input
                   placeholder="Search by name, email, or username..."
                   value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
+                  onChange={e => {
+                    setSearchTerm(e.target.value);
+                    setPage(0);
+                  }}
                   className="pl-9"
                 />
               </div>
             </div>
 
             {/* Status Filter */}
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <Select
+              value={statusFilter}
+              onValueChange={v => {
+                setStatusFilter(v);
+                setPage(0);
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Filter by status" />
               </SelectTrigger>
@@ -565,7 +560,13 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
             </Select>
 
             {/* Role Filter */}
-            <Select value={roleFilter} onValueChange={setRoleFilter}>
+            <Select
+              value={roleFilter}
+              onValueChange={v => {
+                setRoleFilter(v);
+                setPage(0);
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Filter by role" />
               </SelectTrigger>
@@ -587,7 +588,10 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
           <div className="flex items-center justify-between pt-2 border-t">
             <div className="flex items-center space-x-4 text-sm text-muted-foreground">
               <span>
-                Showing {filteredUsers.length} of {users.length} users
+                Showing {page * rowsPerPage + 1}-{Math.min(
+                  (page + 1) * rowsPerPage,
+                  total
+                )} of {total} users
               </span>
               {(searchTerm ||
                 statusFilter !== 'all' ||
@@ -599,6 +603,7 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
                       setSearchTerm('');
                       setStatusFilter('all');
                       setRoleFilter('all');
+                      setPage(0);
                     }}
                     className="h-auto p-1 text-xs"
                   >
@@ -712,11 +717,11 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
               <Users className="h-5 w-5 mr-2" />
               User Directory
               <Badge variant="secondary" className="ml-2">
-                {filteredUsers.length} users
+                {total} users
               </Badge>
             </div>
             <div className="text-sm text-muted-foreground">
-              Total: {users.length} users
+              Page {page + 1} of {Math.max(1, Math.ceil(total / rowsPerPage))}
             </div>
           </CardTitle>
         </CardHeader>
@@ -938,6 +943,37 @@ const UserManagement: React.FC<UserManagementProps> = ({ onUserUpdated }) => {
           )}
         </CardContent>
       </Card>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between mt-4">
+        <p className="text-sm text-muted-foreground">
+          Showing {page * rowsPerPage + 1} to {Math.min(
+            (page + 1) * rowsPerPage,
+            total
+          )} of {total} users
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage(page - 1)}
+            disabled={page === 0 || loading}
+          >
+            Previous
+          </Button>
+          <span className="text-sm">
+            Page {page + 1} of {Math.max(1, Math.ceil(total / rowsPerPage))}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage(page + 1)}
+            disabled={(page + 1) * rowsPerPage >= total || loading}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
 
       {/* Edit User Dialog */}
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>

--- a/frontend/src/services/__tests__/adminApi.responses.test.ts
+++ b/frontend/src/services/__tests__/adminApi.responses.test.ts
@@ -91,8 +91,13 @@ describe('AdminApiService response shapes', () => {
             last_login: null,
             roles: ['admin'],
         }
-        api.get.mockResolvedValueOnce(ok({ items: [user], skip: 0, limit: 1, total: 1 }))
-        const env = await AdminApiService.listUsers(0, 1, true) as any
+        api.get.mockResolvedValueOnce(
+            ok({
+                items: [user],
+                pagination: { skip: 0, limit: 1, total: 1, has_more: false, page: 1, total_pages: 1 },
+            }),
+        )
+        const env = (await AdminApiService.listUsers(0, 1, true)) as any
         expect(env.items[0].username).toBe('alice')
 
         api.get.mockResolvedValueOnce(ok([user]))
@@ -102,8 +107,13 @@ describe('AdminApiService response shapes', () => {
 
     it('returns logs envelope and raw', async () => {
         const log: LogEntry = { timestamp: new Date().toISOString(), level: 'ERROR', message: 'x', module: 'core', user_id: null }
-        api.get.mockResolvedValueOnce(ok({ items: [log], skip: 0, limit: 100, total: 1 }))
-        const env = await AdminApiService.getSystemLogs('ERROR', 100, { envelope: true }) as any
+        api.get.mockResolvedValueOnce(
+            ok({
+                items: [log],
+                pagination: { skip: 0, limit: 100, total: 1, has_more: false, page: 1, total_pages: 1 },
+            }),
+        )
+        const env = (await AdminApiService.getSystemLogs('ERROR', 100, { envelope: true })) as any
         expect(env.items.length).toBe(1)
 
         api.get.mockResolvedValueOnce(ok([log]))
@@ -113,8 +123,13 @@ describe('AdminApiService response shapes', () => {
 
     it('returns audit envelope variants', async () => {
         const entry: AuditEntry = { timestamp: new Date().toISOString(), action: 'LOGIN', user_id: 1 }
-        api.get.mockResolvedValueOnce(ok({ items: [entry], skip: 0, limit: 100, total: 1 }))
-        const env = await AdminApiService.getAuditLogs(0, 100, undefined, undefined, { envelope: true }) as any
+        api.get.mockResolvedValueOnce(
+            ok({
+                items: [entry],
+                pagination: { skip: 0, limit: 100, total: 1, has_more: false, page: 1, total_pages: 1 },
+            }),
+        )
+        const env = (await AdminApiService.getAuditLogs(0, 100, undefined, undefined, { envelope: true })) as any
         expect(env.items[0].action).toBe('LOGIN')
     })
 

--- a/frontend/src/services/adminApi.ts
+++ b/frontend/src/services/adminApi.ts
@@ -226,13 +226,16 @@ export class AdminApiService {
   static async listUsers(
     skip = 0,
     limit = 100,
-    envelope = false
-  ): Promise<
-    | UserWithRoles[]
-    | { items: UserWithRoles[]; skip: number; limit: number; total: number }
-  > {
+    envelope = false,
+    opts?: {
+      search?: string;
+      is_active?: boolean;
+      is_verified?: boolean;
+      is_admin?: boolean;
+    }
+  ): Promise<UserWithRoles[] | PaginatedResponse<UserWithRoles>> {
     const response = await api.get('/admin/users', {
-      params: { skip, limit, envelope },
+      params: { skip, limit, envelope, ...(opts || {}) },
     });
     return response.data;
   }
@@ -431,10 +434,7 @@ export class AdminApiService {
       skip?: number;
       envelope?: boolean;
     }
-  ): Promise<
-    | LogEntry[]
-    | { items: LogEntry[]; skip: number; limit: number; total: number }
-  > {
+  ): Promise<LogEntry[] | PaginatedResponse<LogEntry>> {
     const response = await api.get('/admin/system/logs', {
       params: {
         level,
@@ -465,7 +465,7 @@ export class AdminApiService {
         limit: number;
         total: number;
       }
-    | { items: AuditEntry[]; skip: number; limit: number; total: number }
+    | PaginatedResponse<AuditEntry>
   > {
     const response = await api.get('/admin/audit-logs', {
       params: {


### PR DESCRIPTION
## Summary
- paginate user management list and reload data on search/filter updates
- expose pagination envelope for listUsers and associated tests
- verify backend list_users envelope structure

## Testing
- `pytest` *(fails: No module named 'pandas')*
- `pnpm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: ReferenceError logsLevel is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68975ea5f60c83278daf1620025fce74