### PR TITLE
feat: improve websocket reliability

### DIFF
--- a/frontend/src/components/Charts/RealtimeChart.tsx
+++ b/frontend/src/components/Charts/RealtimeChart.tsx
@@ -144,21 +144,23 @@ export const RealtimeChart: React.FC<RealtimeChartProps> = ({
 
     setupWebSocketSubscription();
 
-    // Setup periodic connection check
-    const connectionCheck = setInterval(() => {
-      const wsConnected = websocketService.isConnectionReady();
+    const unsubscribeStatus = websocketService.subscribeStatus(state => {
+      const wsConnected = state === 'connected';
       if (wsConnected !== isConnected) {
         setIsConnected(wsConnected);
         onConnectionChange?.(wsConnected);
-
-        if (wsConnected && !unsubscribeRef.current) {
-          setupWebSocketSubscription();
-        }
       }
-    }, 2000);
+
+      if (wsConnected && !unsubscribeRef.current) {
+        setupWebSocketSubscription();
+      } else if (!wsConnected && unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    });
 
     return () => {
-      clearInterval(connectionCheck);
+      unsubscribeStatus();
       if (unsubscribeRef.current) {
         unsubscribeRef.current();
         unsubscribeRef.current = null;

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -585,15 +585,14 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
 
   // Monitor connection state
   useEffect(() => {
-    const checkConnection = () => {
-      const wsConnected = notificationsWebSocketService.isConnectionReady();
+    const unsubscribe = notificationsWebSocketService.subscribeStatus(state => {
+      const wsConnected = state === 'connected';
       if (wsConnected !== isConnected) {
         setIsConnected(wsConnected);
       }
-    };
+    });
 
-    const interval = setInterval(checkConnection, 2000);
-    return () => clearInterval(interval);
+    return unsubscribe;
   }, [isConnected]);
 
   // Handle authentication state changes

--- a/frontend/src/hooks/useRealtimeDashboard.ts
+++ b/frontend/src/hooks/useRealtimeDashboard.ts
@@ -307,19 +307,15 @@ export const useRealtimeDashboard = ({
     };
   }, [enabled, fileId, period, isLiveEnabled, connectWebSocket, isConnected]);
 
-  // Update connection state based on WebSocket service state
+  // Update connection state based on WebSocket service status changes
   useEffect(() => {
-    const checkConnectionState = () => {
-      const wsState = dashboardWebSocketService.getConnectionState();
-      setConnectionState(wsState as 'connecting' | 'connected' | 'disconnected');
-      setIsConnected(wsState === 'connected');
+    const unsubscribe = dashboardWebSocketService.subscribeStatus(state => {
+      setConnectionState(state);
+      setIsConnected(state === 'connected');
       setReconnectAttempts(dashboardWebSocketService.getReconnectAttempts());
-    };
+    });
 
-    // Check connection state every 2 seconds
-    const interval = setInterval(checkConnectionState, 2000);
-
-    return () => clearInterval(interval);
+    return unsubscribe;
   }, []);
 
   return {


### PR DESCRIPTION
## Summary
- add heartbeat ping/pong tracking and connection status subscriptions
- implement exponential reconnection backoff and status cleanup
- update real-time components to consume new connection status API

## Testing
- `pnpm vitest run` *(fails: ReferenceError: logsLevel is not defined)*
- `pnpm lint:ci` *(fails: unused vars and ts-ignore warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68975ea79ff88327b8350440ebdbcfc0