### PR TITLE
Align Starlette version with FastAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core Framework and Dependencies
 fastapi==0.104.1
-starlette==0.47.2
+# FastAPI 0.104.1 requires Starlette 0.27.x
+starlette>=0.27.0,<0.28.0
 uvicorn==0.24.0
 gunicorn==21.2.0
 python-multipart==0.0.6


### PR DESCRIPTION
## Summary
- fix dependency conflict by pinning Starlette to the range required by FastAPI 0.104.1

## Testing
- `pre-commit run --files requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689776f7800883278491b7bd9c1fa742