### PR TITLE
refactor: centralize rate limit utilities

### DIFF
--- a/backend/app/api/v1/endpoints/admin.py
+++ b/backend/app/api/v1/endpoints/admin.py
@@ -29,6 +29,7 @@ from app.services.database_monitor import get_db_monitor
 from app.services.file_service import FileService
 from app.services.maintenance_service import MaintenanceService
 from app.services.system_log_service import SystemLogService
+from app.services import rate_limit_service
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
@@ -947,23 +948,7 @@ def clear_rate_limits(
     db: Session = Depends(get_db),
 ) -> Any:
     """Clear all rate limiting records to restore access."""
-    try:
-        from app.core.rate_limiter import RateLimit
-
-        # Delete all rate limit records
-        deleted_count = db.query(RateLimit).delete()
-        db.commit()
-
-        return {
-            "message": "Rate limits cleared successfully",
-            "cleared_records": deleted_count,
-        }
-
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to clear rate limits: {str(e)}",
-        )
+    return rate_limit_service.clear_rate_limits(db)
 
 
 @router.get("/reports/overview", response_model=Dict[str, Any])

--- a/backend/app/api/v1/endpoints/admin/system.py
+++ b/backend/app/api/v1/endpoints/admin/system.py
@@ -11,6 +11,7 @@ from app.models.parameter import Parameter
 from app.models.user import User
 from app.services.file_service import FileService
 from app.services.maintenance_service import MaintenanceService
+from app.services import rate_limit_service
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import PlainTextResponse
 from app.schemas.admin import (
@@ -539,37 +540,10 @@ def clear_rate_limits(
     db: Session = Depends(get_db),
 ) -> Any:
     """Clear all rate limiting records to restore access."""
-    try:
-        from app.core.rate_limiter import RateLimit
-
-        deleted_count = db.query(RateLimit).delete()
-        db.commit()
-
-        return {
-            "message": "Rate limits cleared successfully",
-            "cleared_records": deleted_count,
-        }
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to clear rate limits: {str(e)}",
-        )
+    return rate_limit_service.clear_rate_limits(db)
 
 
 @router.post("/dev-clear-rate-limits", response_model=Dict[str, Any])
 def dev_clear_rate_limits(db: Session = Depends(get_db)) -> Any:
     """Development utility to clear rate limits without auth."""
-    try:
-        from app.core.rate_limiter import RateLimit
-
-        deleted_count = db.query(RateLimit).delete()
-        db.commit()
-        return {
-            "message": "Rate limits cleared successfully",
-            "cleared_records": deleted_count,
-        }
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to clear rate limits: {str(e)}",
-        )
+    return rate_limit_service.clear_rate_limits(db)

--- a/backend/app/services/rate_limit_service.py
+++ b/backend/app/services/rate_limit_service.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.rate_limiter import RateLimit
+
+
+def clear_rate_limits(db: Session) -> Dict[str, Any]:
+    """Remove all rate limiting records and report how many were cleared."""
+    try:
+        deleted_count = db.query(RateLimit).delete()
+        db.commit()
+        return {
+            "message": "Rate limits cleared successfully",
+            "cleared_records": deleted_count,
+        }
+    except Exception as e:  # pragma: no cover - defensive programming
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to clear rate limits: {str(e)}",
+        )

--- a/frontend/src/services/adminApi.ts
+++ b/frontend/src/services/adminApi.ts
@@ -6,12 +6,24 @@
 
 import api from './api';
 import {
+  MaintenanceScheduleItem,
+  MaintenanceSchedules,
+  getMaintenanceSchedules as fetchMaintenanceSchedules,
+  updateMaintenanceSchedules as saveMaintenanceSchedules,
+} from './admin/maintenance';
+import {
+  clearRateLimits as clearSystemRateLimits,
+  devClearRateLimits as devClearSystemRateLimits,
+} from './admin/system';
+import {
   AdminDataTransformer,
   NormalizedSystemStats,
   NormalizedUserActivity,
   PaginatedResponse,
   UserActivity,
 } from '@/types/admin';
+
+export type { MaintenanceScheduleItem, MaintenanceSchedules };
 
 // Types for admin API responses
 export interface SystemStats {
@@ -120,18 +132,6 @@ export interface AuditEntry {
   user_id?: number | null;
   message?: string;
   details?: any;
-}
-
-export interface MaintenanceScheduleItem {
-  id: string;
-  name: string;
-  task: 'cleanup' | 'vacuum' | 'archive' | 'reindex' | 'backup';
-  schedule: string;
-  enabled: boolean;
-}
-
-export interface MaintenanceSchedules {
-  items: MaintenanceScheduleItem[];
 }
 
 export class AdminApiService {
@@ -364,8 +364,7 @@ export class AdminApiService {
     message: string;
     cleared_records: number;
   }> {
-    const response = await api.post('/admin/rate-limits/clear');
-    return response.data;
+    return clearSystemRateLimits();
   }
 
   /**
@@ -375,8 +374,7 @@ export class AdminApiService {
     message: string;
     cleared_records: number;
   }> {
-    const response = await api.post('/admin/dev-clear-rate-limits');
-    return response.data;
+    return devClearSystemRateLimits();
   }
 
   /**
@@ -470,15 +468,13 @@ export class AdminApiService {
 
   // Maintenance schedules
   static async getMaintenanceSchedules(): Promise<MaintenanceSchedules> {
-    const response = await api.get('/admin/maintenance/schedules');
-    return response.data;
+    return fetchMaintenanceSchedules();
   }
 
   static async updateMaintenanceSchedules(
     schedules: MaintenanceSchedules
   ): Promise<MaintenanceSchedules> {
-    const response = await api.put('/admin/maintenance/schedules', schedules);
-    return response.data;
+    return saveMaintenanceSchedules(schedules);
   }
 
   // Manual operations


### PR DESCRIPTION
## Summary
- centralize rate limit clearing logic in a shared backend service
- delegate admin API endpoints to new service to avoid duplication
- reuse existing admin maintenance/system utilities from the frontend AdminApiService

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run test:minimal:ci`
- `npm run lint:ci`


------
https://chatgpt.com/codex/tasks/task_e_68977c2425b88327a6a437a3da172582