### PR TITLE
refactor: adopt design-system form controls in admin UI

### DIFF
--- a/frontend/src/components/Admin/DataManagement.tsx
+++ b/frontend/src/components/Admin/DataManagement.tsx
@@ -32,6 +32,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/design-system/components/Table';
+import { Input } from '@/design-system/components/Input';
+import { Checkbox } from '@/design-system/components/Checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/design-system/components/Select';
 import {
   Dialog,
   DialogContent,
@@ -600,15 +609,19 @@ const DataManagement: React.FC = () => {
               <CardContent>
                 <div className="flex items-center justify-end mb-4 gap-2">
                   <span className="text-xs text-muted-foreground">Window</span>
-                  <select
-                    className="border rounded px-2 py-1 bg-background text-sm"
+                  <Select
                     value={performanceWindow}
-                    onChange={e => setPerformanceWindow(e.target.value as any)}
+                    onValueChange={val => setPerformanceWindow(val as any)}
                   >
-                    <option value="1h">Last 1h</option>
-                    <option value="24h">Last 24h</option>
-                    <option value="7d">Last 7d</option>
-                  </select>
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="1h">Last 1h</SelectItem>
+                      <SelectItem value="24h">Last 24h</SelectItem>
+                      <SelectItem value="7d">Last 7d</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="text-center">
@@ -723,20 +736,19 @@ const DataManagement: React.FC = () => {
                         key={it.id}
                         className="p-3 border rounded flex items-center gap-3"
                       >
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={it.enabled}
-                          onChange={e => {
+                          onCheckedChange={checked => {
                             const next = { ...schedulesDraft };
                             next.items[idx] = {
                               ...it,
-                              enabled: e.target.checked,
+                              enabled: !!checked,
                             } as any;
                             setSchedulesDraft(next);
                           }}
                         />
-                        <input
-                          className="border rounded px-2 py-1 bg-background text-sm flex-1"
+                        <Input
+                          className="flex-1"
                           value={it.name}
                           onChange={e => {
                             const next = { ...schedulesDraft };
@@ -747,32 +759,36 @@ const DataManagement: React.FC = () => {
                             setSchedulesDraft(next);
                           }}
                         />
-                        <select
-                          className="border rounded px-2 py-1 bg-background text-sm"
+                        <Select
                           value={it.task}
-                          onChange={e => {
+                          onValueChange={val => {
                             const next = { ...schedulesDraft };
                             next.items[idx] = {
                               ...it,
-                              task: e.target.value as any,
+                              task: val as any,
                             } as any;
                             setSchedulesDraft(next);
                           }}
                         >
-                          {[
-                            'cleanup',
-                            'vacuum',
-                            'archive',
-                            'reindex',
-                            'backup',
-                          ].map(x => (
-                            <option key={x} value={x}>
-                              {x}
-                            </option>
-                          ))}
-                        </select>
-                        <input
-                          className="border rounded px-2 py-1 bg-background text-sm w-40"
+                          <SelectTrigger className="w-32">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {[
+                              'cleanup',
+                              'vacuum',
+                              'archive',
+                              'reindex',
+                              'backup',
+                            ].map(x => (
+                              <SelectItem key={x} value={x}>
+                                {x}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Input
+                          className="w-40"
                           placeholder="schedule"
                           value={it.schedule}
                           onChange={e => {

--- a/frontend/src/components/AdminDashboard/LogsTab.tsx
+++ b/frontend/src/components/AdminDashboard/LogsTab.tsx
@@ -6,6 +6,14 @@ import {
   CardTitle,
 } from '@/design-system/components/Card';
 import { Button } from '@/design-system/components/Button';
+import { Input } from '@/design-system/components/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/design-system/components/Select';
 import { useAdminStore } from '@/stores/adminStore';
 
 const LogsTab: React.FC = () => {
@@ -39,46 +47,56 @@ const LogsTab: React.FC = () => {
       </CardHeader>
       <CardContent>
         <div className="flex flex-wrap items-center gap-2 mb-4">
-          <select
-            className="border rounded px-2 py-1 bg-background text-sm"
+          <Select
             value={level}
-            onChange={e => handleFilterChange({ level: e.target.value, skip: 0 })}
+            onValueChange={val => handleFilterChange({ level: val, skip: 0 })}
           >
-            {['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].map(l => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-          </select>
-          <select
-            className="border rounded px-2 py-1 bg-background text-sm"
-            value={limit}
-            onChange={e => handleFilterChange({ limit: Number(e.target.value), skip: 0 })}
+            <SelectTrigger className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].map(l => (
+                <SelectItem key={l} value={l}>
+                  {l}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(limit)}
+            onValueChange={val =>
+              handleFilterChange({ limit: Number(val), skip: 0 })
+            }
           >
-            {[50, 100, 200, 500].map(l => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-          </select>
-          <input
+            <SelectTrigger className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[50, 100, 200, 500].map(l => (
+                <SelectItem key={l} value={String(l)}>
+                  {l}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
             type="date"
-            className="border rounded px-2 py-1 bg-background text-sm"
             value={from}
             onChange={e => handleFilterChange({ from: e.target.value, skip: 0 })}
+            className="w-40"
           />
-          <input
+          <Input
             type="date"
-            className="border rounded px-2 py-1 bg-background text-sm"
             value={to}
             onChange={e => handleFilterChange({ to: e.target.value, skip: 0 })}
+            className="w-40"
           />
-          <input
+          <Input
             type="text"
-            className="border rounded px-2 py-1 bg-background text-sm"
             placeholder="Search"
             value={search}
             onChange={e => handleFilterChange({ search: e.target.value, skip: 0 })}
+            className="w-40"
           />
           <Button size="sm" variant="outline" onClick={handleRefresh}>
             Refresh Logs

--- a/frontend/src/components/AdminDashboard/__tests__/LogsTab.filters.test.tsx
+++ b/frontend/src/components/AdminDashboard/__tests__/LogsTab.filters.test.tsx
@@ -38,8 +38,10 @@ describe('LogsTab filters', () => {
     render(<LogsTab />);
 
     const selects = screen.getAllByRole('combobox');
-    await userEvent.selectOptions(selects[0], 'INFO');
-    await userEvent.selectOptions(selects[1], '50');
+    await userEvent.click(selects[0]);
+    await userEvent.click(await screen.findByRole('option', { name: 'INFO' }));
+    await userEvent.click(selects[1]);
+    await userEvent.click(await screen.findByRole('option', { name: '50' }));
 
     const dateInputs = screen.getAllByDisplayValue('');
     await userEvent.type(dateInputs[0], '2025-01-01');

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -30,11 +30,20 @@ import {
 import { Alert, AlertDescription } from '@/design-system/components/Alert';
 import { useAuth } from '@/contexts/AuthContext';
 import { Switch } from '@/design-system/components/Switch';
+import { Input } from '@/design-system/components/Input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/design-system/components/Select';
 import { useAdminStore } from '@/stores/admin';
 import UserManagement from '@/components/Admin/UserManagement';
 import SystemMonitoring from '@/components/Admin/SystemMonitoring';
 import DataManagement from '@/components/Admin/DataManagement';
 import OverviewTab from '@/components/AdminDashboard/OverviewTab';
+import HealthTab from '@/components/AdminDashboard/HealthTab';
 import { toast } from 'sonner';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import * as AdminApi from '@/services/admin';
@@ -374,14 +383,12 @@ const AdminDashboard: React.FC = () => {
               </CardHeader>
               <CardContent>
                 <div className="flex flex-wrap items-center gap-2 mb-4">
-                  <select
-                    className="border rounded px-2 py-1 bg-background text-sm"
+                  <Select
                     value={logsLevel}
-                    onChange={async e => {
-                      const lvl = e.target.value as typeof logsLevel;
-                      setLogsLevel(lvl);
+                    onValueChange={async lvl => {
+                      setLogsLevel(lvl as typeof logsLevel);
                       const resp = await AdminApi.getSystemLogs(
-                        lvl,
+                        lvl as typeof logsLevel,
                         logsLimit,
                         {
                           from: logsFrom || undefined,
@@ -396,19 +403,23 @@ const AdminDashboard: React.FC = () => {
                       setLogsTotal(env.total || 0);
                     }}
                   >
-                    {['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].map(
-                      l => (
-                        <option key={l} value={l}>
-                          {l}
-                        </option>
-                      )
-                    )}
-                  </select>
-                  <select
-                    className="border rounded px-2 py-1 bg-background text-sm"
-                    value={logsLimit}
-                    onChange={async e => {
-                      const lim = Number(e.target.value);
+                    <SelectTrigger className="w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].map(
+                        l => (
+                          <SelectItem key={l} value={l}>
+                            {l}
+                          </SelectItem>
+                        )
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={String(logsLimit)}
+                    onValueChange={async val => {
+                      const lim = Number(val);
                       setLogsLimit(lim);
                       const resp = await AdminApi.getSystemLogs(
                         logsLevel,
@@ -426,30 +437,35 @@ const AdminDashboard: React.FC = () => {
                       setLogsTotal(env.total || 0);
                     }}
                   >
-                    {[50, 100, 200, 500].map(l => (
-                      <option key={l} value={l}>
-                        {l}
-                      </option>
-                    ))}
-                  </select>
-                  <input
+                    <SelectTrigger className="w-28">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[50, 100, 200, 500].map(l => (
+                        <SelectItem key={l} value={String(l)}>
+                          {l}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
                     type="date"
-                    className="border rounded px-2 py-1 bg-background text-sm"
                     value={logsFrom}
                     onChange={e => setLogsFrom(e.target.value)}
+                    className="w-40"
                   />
-                  <input
+                  <Input
                     type="date"
-                    className="border rounded px-2 py-1 bg-background text-sm"
                     value={logsTo}
                     onChange={e => setLogsTo(e.target.value)}
+                    className="w-40"
                   />
-                  <input
+                  <Input
                     type="text"
-                    className="border rounded px-2 py-1 bg-background text-sm"
                     placeholder="Search"
                     value={logsSearch}
                     onChange={e => setLogsSearch(e.target.value)}
+                    className="w-40"
                   />
                   <Button
                     size="sm"
@@ -618,9 +634,9 @@ const AdminDashboard: React.FC = () => {
               </CardHeader>
               <CardContent>
                 <div className="flex items-center gap-2 mb-4 flex-wrap">
-                  <input
+                  <Input
                     type="number"
-                    className="border rounded px-2 py-1 bg-background text-sm w-24"
+                    className="w-24"
                     placeholder="Skip"
                     value={auditFilters.skip}
                     onChange={e =>
@@ -630,9 +646,9 @@ const AdminDashboard: React.FC = () => {
                       })
                     }
                   />
-                  <input
+                  <Input
                     type="number"
-                    className="border rounded px-2 py-1 bg-background text-sm w-24"
+                    className="w-24"
                     placeholder="Limit"
                     value={auditFilters.limit}
                     onChange={e =>
@@ -642,9 +658,9 @@ const AdminDashboard: React.FC = () => {
                       })
                     }
                   />
-                  <input
+                  <Input
                     type="number"
-                    className="border rounded px-2 py-1 bg-background text-sm w-32"
+                    className="w-32"
                     placeholder="User ID"
                     value={auditFilters.userId || ''}
                     onChange={e =>
@@ -656,9 +672,9 @@ const AdminDashboard: React.FC = () => {
                       })
                     }
                   />
-                  <input
+                  <Input
                     type="text"
-                    className="border rounded px-2 py-1 bg-background text-sm w-40"
+                    className="w-40"
                     placeholder="Action"
                     value={auditFilters.action || ''}
                     onChange={e =>
@@ -668,17 +684,17 @@ const AdminDashboard: React.FC = () => {
                       })
                     }
                   />
-                  <input
+                  <Input
                     type="date"
-                    className="border rounded px-2 py-1 bg-background text-sm"
                     value={auditFrom}
                     onChange={e => setAuditFrom(e.target.value)}
+                    className="w-40"
                   />
-                  <input
+                  <Input
                     type="date"
-                    className="border rounded px-2 py-1 bg-background text-sm"
                     value={auditTo}
                     onChange={e => setAuditTo(e.target.value)}
+                    className="w-40"
                   />
                   <Button
                     size="sm"
@@ -810,17 +826,17 @@ const AdminDashboard: React.FC = () => {
                     <div className="flex items-center justify-between">
                       <CardTitle>Security Overview</CardTitle>
                       <div className="space-x-2 flex items-center">
-                        <input
+                        <Input
                           type="date"
-                          className="border rounded px-2 py-1 bg-background text-sm"
                           value={securityFrom}
                           onChange={e => setSecurityFrom(e.target.value)}
+                          className="w-40"
                         />
-                        <input
+                        <Input
                           type="date"
-                          className="border rounded px-2 py-1 bg-background text-sm"
                           value={securityTo}
                           onChange={e => setSecurityTo(e.target.value)}
+                          className="w-40"
                         />
                         <Button
                           variant="outline"

--- a/frontend/src/pages/__tests__/AdminDashboard.logs-filters.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboard.logs-filters.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -44,13 +44,13 @@ describe('AdminDashboard Logs filters', () => {
         const logsSection = logsCardTitle.closest('div')!.parentElement!.parentElement as HTMLElement
 
         // Change level to INFO (first select)
-        const selects = Array.from(logsSection.querySelectorAll('select'))
-        const levelSel = selects[0] as HTMLSelectElement
-        await userEvent.selectOptions(levelSel, 'INFO')
+        const combos = within(logsSection).getAllByRole('combobox')
+        await userEvent.click(combos[0])
+        await userEvent.click(await screen.findByRole('option', { name: 'INFO' }))
 
         // Change limit to 50 (second select)
-        const limitSel = selects[1] as HTMLSelectElement
-        await userEvent.selectOptions(limitSel, '50')
+        await userEvent.click(combos[1])
+        await userEvent.click(await screen.findByRole('option', { name: '50' }))
 
         // Set date range and search (date inputs within logs section)
         const dateInputs = Array.from(logsSection.querySelectorAll('input[type="date"]')) as HTMLInputElement[]


### PR DESCRIPTION
## Summary
- replace raw inputs and selects in AdminDashboard with design-system Input and Select components
- swap DataManagement and LogsTab form elements for design-system Input, Select, and Checkbox
- adjust tests for new combobox interactions

## Testing
- `npm run test:minimal:ci` *(fails: 21 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68977c499968832788a423a2f33c24e2