### PR TITLE
fix: remove duplicate audit log import

### DIFF
--- a/backend/app/api/v1/endpoints/admin.py
+++ b/backend/app/api/v1/endpoints/admin.py
@@ -24,7 +24,6 @@ from app.schemas.user import User as UserSchema
 from app.schemas.user import UserWithRoles
 from app.services.audit_service import log_audit
 from app.services.auth_service import AuthService
-from app.services.audit_service import log_audit
 from app.services.database_monitor import get_db_monitor
 from app.services.file_service import FileService
 from app.services.maintenance_service import MaintenanceService


### PR DESCRIPTION
## Summary
- remove redundant `log_audit` import in admin endpoint

## Testing
- `flake8 backend/app/api/v1/endpoints/admin.py --max-line-length=88 --extend-ignore=E203,W503 | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68977c90114c832794c8c3e203a2c433