### PR TITLE
feat: add log filter form story and hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,17 +14,24 @@ repos:
     hooks:
       - id: frontend-lint
         name: Frontend ESLint
-        entry: bash -c 'cd frontend && npm run lint'
+        entry: bash -c 'npx eslint --config frontend/.eslintrc.cjs "$@"' --
         language: system
         files: ^frontend/.*\.(ts|tsx|js|jsx)$
-        pass_filenames: false
+        pass_filenames: true
 
       - id: frontend-format
         name: Frontend Prettier
-        entry: bash -c 'cd frontend && npm run format'
+        entry: bash -c 'if [ "$#" -gt 0 ]; then npx prettier --write "$@"; fi' --
         language: system
         files: ^frontend/.*\.(ts|tsx|js|jsx|json|css|md)$
-        pass_filenames: false
+        pass_filenames: true
+
+      - id: no-legacy-ui-imports
+        name: Disallow legacy ui imports
+        entry: bash -c 'if grep -n "@/components/ui" "$@"; then echo "Use design-system components instead of @/components/ui"; exit 1; fi'
+        language: system
+        files: ^frontend/.*\.(ts|tsx)$
+        pass_filenames: true
 
   # Backend hooks
   - repo: https://github.com/psf/black

--- a/frontend/src/components/AdminDashboard/LogFilterForm.stories.tsx
+++ b/frontend/src/components/AdminDashboard/LogFilterForm.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import LogFilterForm from './LogFilterForm';
+
+const meta: Meta<typeof LogFilterForm> = {
+  title: 'Admin/LogFilterForm',
+  component: LogFilterForm,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LogFilterForm>;
+
+export const Default: Story = {
+  args: {
+    level: 'INFO',
+    limit: 100,
+    from: '',
+    to: '',
+    search: '',
+    total: 0,
+    skip: 0,
+    onFilterChange: action('filter change'),
+    onPrev: action('prev'),
+    onNext: action('next'),
+    onRefresh: action('refresh'),
+  },
+};

--- a/frontend/src/components/AdminDashboard/LogFilterForm.tsx
+++ b/frontend/src/components/AdminDashboard/LogFilterForm.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Button } from '@/design-system/components/Button';
+import { Input } from '@/design-system/components/Input';
+import type { LogsState } from '@/stores/admin/types';
+
+interface LogFilterFormProps {
+  level: LogsState['level'];
+  limit: number;
+  from: string;
+  to: string;
+  search: string;
+  total: number;
+  skip: number;
+  onFilterChange: (
+    updates: Partial<Omit<LogsState, 'items' | 'total'>>
+  ) => Promise<void> | void;
+  onPrev: () => Promise<void> | void;
+  onNext: () => Promise<void> | void;
+  onRefresh: () => Promise<void> | void;
+}
+
+const levels: LogsState['level'][] = [
+  'DEBUG',
+  'INFO',
+  'WARNING',
+  'ERROR',
+  'CRITICAL',
+];
+
+const limits = [50, 100, 200, 500];
+
+const LogFilterForm: React.FC<LogFilterFormProps> = ({
+  level,
+  limit,
+  from,
+  to,
+  search,
+  total,
+  skip,
+  onFilterChange,
+  onPrev,
+  onNext,
+  onRefresh,
+}) => {
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <select
+        className="border rounded px-2 py-1 bg-background text-sm"
+        value={level}
+        onChange={e =>
+          onFilterChange({ level: e.target.value as any, skip: 0 })
+        }
+      >
+        {levels.map(l => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+      <select
+        className="border rounded px-2 py-1 bg-background text-sm"
+        value={limit}
+        onChange={e =>
+          onFilterChange({ limit: Number(e.target.value), skip: 0 })
+        }
+      >
+        {limits.map(l => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+      <Input
+        type="date"
+        className="w-40"
+        value={from}
+        onChange={e => onFilterChange({ from: e.target.value, skip: 0 })}
+      />
+      <Input
+        type="date"
+        className="w-40"
+        value={to}
+        onChange={e => onFilterChange({ to: e.target.value, skip: 0 })}
+      />
+      <Input
+        type="text"
+        placeholder="Search"
+        className="w-40"
+        value={search}
+        onChange={e => onFilterChange({ search: e.target.value, skip: 0 })}
+      />
+      <Button size="sm" variant="outline" onClick={onRefresh}>
+        Refresh Logs
+      </Button>
+      <div className="ml-auto flex items-center gap-2 text-xs">
+        <span>
+          {total > 0
+            ? `${Math.min(skip + 1, total)}-${Math.min(skip + limit, total)} of ${total}`
+            : '0-0 of 0'}
+        </span>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onPrev}
+          disabled={skip <= 0}
+        >
+          Prev
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onNext}
+          disabled={skip + limit >= total}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default LogFilterForm;

--- a/frontend/src/components/AdminDashboard/LogsTab.tsx
+++ b/frontend/src/components/AdminDashboard/LogsTab.tsx
@@ -5,32 +5,13 @@ import {
   CardHeader,
   CardTitle,
 } from '@/design-system/components/Card';
-import { Button } from '@/design-system/components/Button';
-import { useAdminStore } from '@/stores/adminStore';
+import { useLogFilters } from '@/hooks/useLogFilters';
+import LogFilterForm from './LogFilterForm';
 
 const LogsTab: React.FC = () => {
-  const { logs, updateLogsFilters, fetchLogsData } = useAdminStore();
+  const { logs, handleFilterChange, handlePrev, handleNext, handleRefresh } =
+    useLogFilters();
   const { items, total, skip, limit, level, from, to, search } = logs;
-
-  const handleFilterChange = async (updates: any) => {
-    updateLogsFilters(updates);
-    await fetchLogsData();
-  };
-
-  const handlePrev = async () => {
-    const newSkip = Math.max(0, skip - limit);
-    await handleFilterChange({ skip: newSkip });
-  };
-
-  const handleNext = async () => {
-    const newSkip = skip + limit;
-    if (newSkip >= total) return;
-    await handleFilterChange({ skip: newSkip });
-  };
-
-  const handleRefresh = async () => {
-    await handleFilterChange({ skip: 0 });
-  };
 
   return (
     <Card>
@@ -38,77 +19,28 @@ const LogsTab: React.FC = () => {
         <CardTitle>System Logs</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="flex flex-wrap items-center gap-2 mb-4">
-          <select
-            className="border rounded px-2 py-1 bg-background text-sm"
-            value={level}
-            onChange={e => handleFilterChange({ level: e.target.value, skip: 0 })}
-          >
-            {['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].map(l => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-          </select>
-          <select
-            className="border rounded px-2 py-1 bg-background text-sm"
-            value={limit}
-            onChange={e => handleFilterChange({ limit: Number(e.target.value), skip: 0 })}
-          >
-            {[50, 100, 200, 500].map(l => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-          </select>
-          <input
-            type="date"
-            className="border rounded px-2 py-1 bg-background text-sm"
-            value={from}
-            onChange={e => handleFilterChange({ from: e.target.value, skip: 0 })}
-          />
-          <input
-            type="date"
-            className="border rounded px-2 py-1 bg-background text-sm"
-            value={to}
-            onChange={e => handleFilterChange({ to: e.target.value, skip: 0 })}
-          />
-          <input
-            type="text"
-            className="border rounded px-2 py-1 bg-background text-sm"
-            placeholder="Search"
-            value={search}
-            onChange={e => handleFilterChange({ search: e.target.value, skip: 0 })}
-          />
-          <Button size="sm" variant="outline" onClick={handleRefresh}>
-            Refresh Logs
-          </Button>
-          <div className="ml-auto flex items-center gap-2 text-xs">
-            <span>
-              {total > 0
-                ? `${Math.min(skip + 1, total)}-${Math.min(skip + limit, total)} of ${total}`
-                : '0-0 of 0'}
-            </span>
-            <Button size="sm" variant="outline" onClick={handlePrev} disabled={skip <= 0}>
-              Prev
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleNext}
-              disabled={skip + limit >= total}
-            >
-              Next
-            </Button>
-          </div>
-        </div>
+        <LogFilterForm
+          level={level}
+          limit={limit}
+          from={from}
+          to={to}
+          search={search}
+          total={total}
+          skip={skip}
+          onFilterChange={handleFilterChange}
+          onPrev={handlePrev}
+          onNext={handleNext}
+          onRefresh={handleRefresh}
+        />
         <div className="border rounded">
           <div className="max-h-96 overflow-auto text-xs font-mono">
             {items.length > 0 ? (
               items.map((log, idx) => (
                 <div key={idx} className="px-3 py-2 border-b">
                   <div className="flex items-center justify-between">
-                    <span className="font-semibold">[{log.level}] {log.module}</span>
+                    <span className="font-semibold">
+                      [{log.level}] {log.module}
+                    </span>
                     <span className="text-muted-foreground">
                       {new Date(log.timestamp).toLocaleString()}
                     </span>

--- a/frontend/src/hooks/useAdminData.ts
+++ b/frontend/src/hooks/useAdminData.ts
@@ -1,0 +1,10 @@
+import { useAdminStore } from '@/stores/adminStore';
+
+export const useAdminData = () => {
+  const logs = useAdminStore(state => state.logs);
+  const updateLogsFilters = useAdminStore(state => state.updateLogsFilters);
+  const fetchLogsData = useAdminStore(state => state.fetchLogsData);
+  return { logs, updateLogsFilters, fetchLogsData };
+};
+
+export type UseAdminDataReturn = ReturnType<typeof useAdminData>;

--- a/frontend/src/hooks/useLogFilters.ts
+++ b/frontend/src/hooks/useLogFilters.ts
@@ -1,0 +1,39 @@
+import type { LogsState } from '@/stores/admin/types';
+import { useAdminData } from './useAdminData';
+
+export const useLogFilters = () => {
+  const { logs, updateLogsFilters, fetchLogsData } = useAdminData();
+  const { skip, limit, total } = logs;
+
+  const handleFilterChange = async (
+    updates: Partial<Omit<LogsState, 'items' | 'total'>>
+  ) => {
+    updateLogsFilters(updates);
+    await fetchLogsData();
+  };
+
+  const handlePrev = async () => {
+    const newSkip = Math.max(0, skip - limit);
+    await handleFilterChange({ skip: newSkip });
+  };
+
+  const handleNext = async () => {
+    const newSkip = skip + limit;
+    if (newSkip >= total) return;
+    await handleFilterChange({ skip: newSkip });
+  };
+
+  const handleRefresh = async () => {
+    await handleFilterChange({ skip: 0 });
+  };
+
+  return {
+    logs,
+    handleFilterChange,
+    handlePrev,
+    handleNext,
+    handleRefresh,
+  };
+};
+
+export type UseLogFiltersReturn = ReturnType<typeof useLogFilters>;


### PR DESCRIPTION
## Summary
- extract LogsTab filter controls into reusable `LogFilterForm`
- add Storybook entry for `LogFilterForm` and encapsulate state logic with custom hooks
- tighten pre-commit with eslint/prettier runners and guard against legacy UI imports

## Testing
- `pre-commit run --files frontend/src/components/AdminDashboard/LogFilterForm.tsx frontend/src/components/AdminDashboard/LogFilterForm.stories.tsx frontend/src/components/AdminDashboard/LogsTab.tsx frontend/src/hooks/useAdminData.ts frontend/src/hooks/useLogFilters.ts .pre-commit-config.yaml`
- `pytest` *(fails: ERROR backend/tests/test_admin_improvements.py::TestEnhancedUserListing::test_user_listing_filtering_parameters, ERROR backend/tests/test_admin_improvements.py::TestEnhancedAuditLogs::test_audit_logs_filtering_parameters, ERROR backend/tests/test_admin_improvements.py::TestRealActivityMetrics::test_activity_metrics_queries_audit_logs, ERROR backend/tests/test_admin_improvements.py::TestMaintenanceTasks::test_backup_endpoint_uses_celery, ERROR backend/tests/test_admin_improvements.py::TestMaintenanceTasks::test_export_endpoint_uses_celery, ERROR backend/tests/test_admin_improvements.py::TestMaintenanceTasks::test_reindex_endpoint_uses_celery, ERROR backend/tests/test_admin_improvements.py::TestSecurityAuditEnhancements::test_security_audit_queries_real_data, ERROR backend/tests/test_admin_improvements.py::TestSystemMetricsEnhancements::test_system_metrics_uses_real_data`)


------
https://chatgpt.com/codex/tasks/task_e_68977ca308e08327be5f961093662427