### PR TITLE
Add contributing guidelines and RFC process with PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+
+Describe the purpose of this pull request.
+
+## Checklist
+- [ ] Accessibility features considered
+- [ ] Documentation updated or added
+- [ ] Tokens follow naming conventions

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ See `/tasks/README.md` for detailed task breakdowns and progress tracking.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+Refer to the [Contributing Guidelines](docs/contributing.md) for token naming rules, component expectations, and review workflow. For major changes, start with the [RFC process](docs/rfc.md).
+
 ### Code Quality
 
 - Frontend: ESLint + Prettier

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,17 @@ This directory contains the main project documentation organized by category.
 ## Project Requirements Documents (PRDs)
 
 - **[PRD_V1.md](./PRD_V1.md)** - Original Product Requirements Document
-- **[PRD_V2.md](./PRD_V2.md)** - Updated Product Requirements Document  
+- **[PRD_V2.md](./PRD_V2.md)** - Updated Product Requirements Document
 - **[PRD_Login_Reports_Components.md](./PRD_Login_Reports_Components.md)** - Login, Reports, and Components Requirements
 
 ## Development Documentation
 
 - **[AGENTS.md](./AGENTS.md)** - AI Agents and Development Guidelines
+
+## Contributor Guidelines
+
+- **[contributing.md](./contributing.md)** - Token naming, component standards, and review workflow
+- **[rfc.md](./rfc.md)** - Proposal submission and approval process
 
 ## Backend Documentation
 
@@ -52,4 +57,4 @@ Task documentation is located in `../tasks/`:
 - [Backend Docs](../backend/docs/)
 - [Frontend Docs](../frontend/docs/)
 - [Tasks](../tasks/)
-- [Main Project README](../README.md) 
+- [Main Project README](../README.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,19 @@
+# Contributing Guidelines
+
+This guide explains how to contribute to the FinVision project and maintain consistency across the codebase.
+
+## Token Naming
+- Prefix design tokens with `fin-` to denote project scope.
+- Use lowercase, hyphen-separated names (e.g., `fin-primary-color`).
+- Group tokens by category (e.g., color, spacing) for clarity.
+
+## Component Guidelines
+- Build components using the defined design tokens.
+- Keep components small, focused, and reusable.
+- Document new components in the storybook or relevant docs.
+
+## Review Workflow
+1. Create a branch for your change.
+2. Ensure pre-commit checks and tests pass.
+3. Open a pull request and request review.
+4. Address feedback and obtain at least one approval before merging.

--- a/docs/rfc.md
+++ b/docs/rfc.md
@@ -1,0 +1,15 @@
+# Request for Comments (RFC) Process
+
+The RFC process is used for proposing substantial changes to the project.
+
+## Submission
+1. Create a new RFC document under `docs/rfcs/` or open an issue describing the proposal.
+2. Provide context, motivation, and a detailed technical plan.
+
+## Review
+1. Share the RFC with maintainers and gather feedback.
+2. Iterate on the proposal until concerns are resolved.
+
+## Approval
+- Obtain approval from at least two maintainers.
+- Merge the RFC and reference it in related pull requests.


### PR DESCRIPTION
## Summary
- add contributing guide covering token naming, component rules and review workflow
- introduce RFC process documentation
- include pull request template with accessibility, docs and token checks
- link new docs from main README and docs index

## Testing
- `pre-commit run --files .github/pull_request_template.md README.md docs/contributing.md docs/rfc.md docs/README.md`
- `python run_tests.py --quick` *(fails: can't open file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68978309b5d08327b7f90cbbc72a0ff8