### PR TITLE
feat: add theme contrast validation and switcher

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,34 @@
+# Themes
+
+The front-end provides light and dark palettes backed by CSS custom properties.
+Theme definitions live in JSON files under `frontend/src/design-system/tokens/themes`.
+Each file maps a CSS variable name (for example `--primary`) to a hex color and
+includes a `-foreground` variant for readable text.
+
+## Creating a custom theme
+
+1. Copy one of the existing theme files (`light.json` or `dark.json`) and rename
+   it to your theme name.
+2. Adjust the color values as needed. Keep keys the same so components can read
+   them as CSS variables.
+3. Verify accessibility by running:
+
+   ```bash
+   node frontend/scripts/contrast-check.js
+   ```
+
+   The script checks that every color pair meets WCAG AA contrast ratios.
+
+## Switching themes at runtime
+
+Use the `setTheme` helper to apply a theme and update the CSS variables on the
+`document.documentElement`:
+
+```ts
+import { setTheme } from '@/design-system/theme-switcher';
+
+setTheme('dark'); // switch to dark mode
+```
+
+The helper also sets `data-theme` on the root element, allowing additional
+styling if needed.

--- a/frontend/scripts/contrast-check.js
+++ b/frontend/scripts/contrast-check.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const THEMES_DIR = path.join(__dirname, '../src/design-system/tokens/themes');
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const full = normalized.length === 3
+    ? normalized.split('').map((c) => c + c).join('')
+    : normalized;
+  const num = parseInt(full, 16);
+  return [num >> 16 & 255, num >> 8 & 255, num & 255];
+}
+
+function luminance(r, g, b) {
+  const a = [r, g, b].map((v) => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+}
+
+function contrast(hex1, hex2) {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const L1 = luminance(r1, g1, b1);
+  const L2 = luminance(r2, g2, b2);
+  const [hi, lo] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function checkTheme(name, tokens) {
+  const pairs = [];
+  if (tokens['--background'] && tokens['--foreground']) {
+    pairs.push(['--background', '--foreground']);
+  }
+  Object.keys(tokens).forEach((key) => {
+    if (key.endsWith('-foreground')) {
+      const base = key.replace('-foreground', '');
+      if (tokens[base]) {
+        pairs.push([base, key]);
+      }
+    }
+  });
+
+  const failures = [];
+  pairs.forEach(([bg, fg]) => {
+    const ratio = contrast(tokens[bg], tokens[fg]);
+    if (ratio < 4.5) {
+      failures.push(`${bg} vs ${fg} = ${ratio.toFixed(2)}`);
+    }
+  });
+
+  if (failures.length) {
+    throw new Error(`${name} theme contrast failures:\n${failures.join('\n')}`);
+  }
+}
+
+['light', 'dark'].forEach((name) => {
+  const file = path.join(THEMES_DIR, `${name}.json`);
+  const raw = fs.readFileSync(file, 'utf8');
+  const tokens = JSON.parse(raw);
+  checkTheme(name, tokens);
+});
+
+console.log('All theme contrast ratios meet WCAG AA');

--- a/frontend/src/design-system/theme-switcher.ts
+++ b/frontend/src/design-system/theme-switcher.ts
@@ -1,0 +1,20 @@
+import light from './tokens/themes/light.json';
+import dark from './tokens/themes/dark.json';
+
+const themes: Record<string, Record<string, string>> = {
+  light,
+  dark,
+};
+
+export function setTheme(themeName: string): void {
+  const theme = themes[themeName];
+  if (!theme) {
+    console.warn(`Theme "${themeName}" not found`);
+    return;
+  }
+  const root = document.documentElement;
+  Object.entries(theme).forEach(([key, value]) => {
+    root.style.setProperty(key, value);
+  });
+  root.dataset.theme = themeName;
+}

--- a/frontend/src/design-system/tokens/themes/dark.json
+++ b/frontend/src/design-system/tokens/themes/dark.json
@@ -1,0 +1,12 @@
+{
+  "--background": "#0f172a",
+  "--foreground": "#f8fafc",
+  "--primary": "#2563eb",
+  "--primary-foreground": "#f8fafc",
+  "--secondary": "#334155",
+  "--secondary-foreground": "#e2e8f0",
+  "--muted": "#1e293b",
+  "--muted-foreground": "#94a3b8",
+  "--destructive": "#dc2626",
+  "--destructive-foreground": "#f8fafc"
+}

--- a/frontend/src/design-system/tokens/themes/light.json
+++ b/frontend/src/design-system/tokens/themes/light.json
@@ -1,0 +1,12 @@
+{
+  "--background": "#ffffff",
+  "--foreground": "#0f172a",
+  "--primary": "#2563eb",
+  "--primary-foreground": "#ffffff",
+  "--secondary": "#94a3b8",
+  "--secondary-foreground": "#1e293b",
+  "--muted": "#f1f5f9",
+  "--muted-foreground": "#475569",
+  "--destructive": "#b91c1c",
+  "--destructive-foreground": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- add WCAG contrast tests for theme palettes
- introduce light/dark theme token files and runtime switcher
- document custom theme creation and switching

## Testing
- `node frontend/scripts/contrast-check.js`
- `pre-commit run --files frontend/src/design-system/tokens/themes/light.json frontend/src/design-system/tokens/themes/dark.json frontend/scripts/contrast-check.js frontend/src/design-system/theme-switcher.ts docs/themes.md` *(fails: Missing script "lint", Missing script "format")*
- `python run_tests.py --quick` *(fails: file not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897830ae6648327952907ead4e97276