### PR TITLE
Define global auditFilters to prevent admin console error

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,17 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 
+declare global {
+  interface Window {
+    auditFilters?: unknown;
+  }
+}
+
+if (typeof window !== 'undefined' && window.auditFilters === undefined) {
+  // Ensure global auditFilters is defined to prevent ReferenceError in admin pages
+  window.auditFilters = [];
+}
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element not found');
@@ -11,5 +22,5 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Ensure `auditFilters` global variable exists to avoid ReferenceError in admin page scripts

## Testing
- `npx prettier src/main.tsx --write`
- `npx eslint src/main.tsx`
- `pre-commit run --files frontend/src/main.tsx` *(fails: Frontend ESLint reports 7 errors, 44 warnings)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689783fb3094832799fa34cd5975f350