### PR TITLE
refactor: remove unused imports

### DIFF
--- a/backend/app/core/websocket_manager.py
+++ b/backend/app/core/websocket_manager.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Set, Optional, Any
 import json
 import asyncio
 from datetime import datetime
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import WebSocket
 from enum import Enum
 import logging
 

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Any, Optional, Tuple, Union
 import logging
 from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_, desc, func
+from sqlalchemy import and_, desc, func
 from dataclasses import dataclass
 from enum import Enum
 
@@ -25,7 +25,6 @@ from app.services.dashboard_metrics import DashboardMetricsService
 from app.services.financial_extractor import FinancialExtractor
 from app.services.chart_data_service import (
     ChartDataService,
-    TimeGranularity,
 )
 from app.services.metrics_calculation_service import (
     MetricsCalculationService,

--- a/backend/app/services/monte_carlo_service.py
+++ b/backend/app/services/monte_carlo_service.py
@@ -15,7 +15,6 @@ from app.models.parameter import (
     ParameterValue,
     Scenario,
     MonteCarloSimulation,
-    ScenarioParameter,
 )
 from app.models.user import User
 from app.services.formula_engine import FormulaEngine

--- a/backend/tests/test_user_activity.py
+++ b/backend/tests/test_user_activity.py
@@ -5,7 +5,7 @@ from app.models.audit import AuditLog
 from app.models.base import SessionLocal, engine
 from app.models.file import FileStatus, UploadedFile
 from app.models.financial import FinancialStatement
-from app.models.mfa import MFAToken  # noqa: F401
+from app.models.mfa import MFAToken
 from app.models.notification import Notification  # noqa: F401
 from app.models.parameter import Scenario
 from app.models.user import User
@@ -16,6 +16,9 @@ from sqlalchemy import event
 app = FastAPI()
 app.include_router(admin_router, prefix="/api/v1/admin")
 client = TestClient(app)
+
+# Ensure MFAToken model is registered for SQLAlchemy mappings
+_ = MFAToken
 
 
 def _seed_data():


### PR DESCRIPTION
## Summary
- prune unused imports from dashboard, Monte Carlo service, and WebSocket manager
- explicitly reference MFAToken in tests so model registration doesn't trigger unused warnings

## Testing
- `pytest backend/tests/test_user_activity.py::test_user_activity_counts_and_query_efficiency -q`

------
https://chatgpt.com/codex/tasks/task_e_68978c5b7e408327b9cda410f9c6228a