### PR TITLE
chore: ensure tailwind config paths are safe

### DIFF
--- a/scripts/generate-tailwind-config.ts
+++ b/scripts/generate-tailwind-config.ts
@@ -11,8 +11,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT = path.resolve(__dirname, '..');
 
-const TOKENS_PATH = path.resolve(ROOT, 'frontend', 'src', 'design-system', 'tokens.json');
-const OUTPUT_PATH = path.resolve(ROOT, 'frontend', 'tailwind.config.js');
+function resolvePath(...segments: string[]): string {
+  const resolved = path.resolve(ROOT, ...segments);
+  if (!resolved.startsWith(ROOT)) {
+    throw new Error('Resolved path is outside project root');
+  }
+  return resolved;
+}
+
 
 function serialize(obj: unknown, indent = 2): string {
   return JSON.stringify(obj, null, indent)
@@ -36,14 +42,16 @@ function buildConfig(tokens: any): string {
 }
 
 function main() {
-  if (!fs.existsSync(TOKENS_PATH)) {
-    throw new Error(`tokens.json not found at ${TOKENS_PATH}`);
+  const tokensPath = resolvePath('frontend', 'src', 'design-system', 'tokens.json');
+  if (!fs.existsSync(tokensPath)) {
+    throw new Error(`tokens.json not found at ${tokensPath}`);
   }
-  const tokensRaw = fs.readFileSync(TOKENS_PATH, 'utf8');
+  const tokensRaw = fs.readFileSync(tokensPath, 'utf8');
   const tokens = JSON.parse(tokensRaw);
   const out = buildConfig(tokens);
-  fs.writeFileSync(OUTPUT_PATH, out, 'utf8');
-  console.log(`Generated ${path.relative(ROOT, OUTPUT_PATH)}`);
+  const outputPath = resolvePath('frontend', 'tailwind.config.js');
+  fs.writeFileSync(outputPath, out, 'utf8');
+  console.log(`Generated ${path.relative(ROOT, outputPath)}`);
 }
 
 main();


### PR DESCRIPTION
## Summary
- sanitize paths when generating the Tailwind config to prevent traversal outside repo

## Testing
- `pre-commit run --files scripts/generate-tailwind-config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68978c7e55f48327ac80c02b20aef448