### PR TITLE
Fix Railway start command to use virtualenv Python

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "cd backend && python start.py"
+    "startCommand": "cd backend && /opt/venv/bin/python start.py"
   }
 }


### PR DESCRIPTION
## Summary
- use virtualenv's Python binary in Railway start command to ensure required packages like Alembic are available at runtime

## Testing
- `pre-commit run --files railway.json`
- `pytest` *(fails: KeyboardInterrupt after 1 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6897979306fc8327be995f1ce19a9408