### PR TITLE
Improve theme contrast validation and switching

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -9,12 +9,12 @@ includes a `-foreground` variant for readable text.
 
 1. Copy one of the existing theme files (`light.json` or `dark.json`) and rename
    it to your theme name.
-2. Adjust the color values as needed. Keep keys the same so components can read
-   them as CSS variables.
+2. Fill in color values for all tokens (e.g., `--accent` / `--accent-foreground`,
+   `--border`, `--input`, `--ring`).
 3. Verify accessibility by running:
 
    ```bash
-   node frontend/scripts/contrast-check.js
+   node scripts/contrast-check.js
    ```
 
    The script checks that every color pair meets WCAG AA contrast ratios.
@@ -22,13 +22,14 @@ includes a `-foreground` variant for readable text.
 ## Switching themes at runtime
 
 Use the `setTheme` helper to apply a theme and update the CSS variables on the
-`document.documentElement`:
+`document.documentElement`. A `toggleTheme` helper is also provided:
 
 ```ts
-import { setTheme } from '@/design-system/theme-switcher';
+import { setTheme, toggleTheme } from '@/design-system/theme-switcher';
 
-setTheme('dark'); // switch to dark mode
+setTheme('dark');   // switch to dark mode
+toggleTheme();      // toggle based on current theme
 ```
 
-The helper also sets `data-theme` on the root element, allowing additional
+The helpers set `data-theme` on the root element, allowing additional
 styling if needed.

--- a/frontend/src/design-system/theme-switcher.ts
+++ b/frontend/src/design-system/theme-switcher.ts
@@ -1,12 +1,14 @@
 import light from './tokens/themes/light.json';
 import dark from './tokens/themes/dark.json';
 
-const themes: Record<string, Record<string, string>> = {
+export type ThemeName = 'light' | 'dark';
+
+const themes: Record<ThemeName, Record<string, string>> = {
   light,
   dark,
 };
 
-export function setTheme(themeName: string): void {
+export function setTheme(themeName: ThemeName): void {
   const theme = themes[themeName];
   if (!theme) {
     console.warn(`Theme "${themeName}" not found`);
@@ -17,4 +19,11 @@ export function setTheme(themeName: string): void {
     root.style.setProperty(key, value);
   });
   root.dataset.theme = themeName;
+}
+
+export function toggleTheme(): void {
+  const current =
+    (document.documentElement.dataset.theme as ThemeName) || 'light';
+  const next = current === 'light' ? 'dark' : 'light';
+  setTheme(next);
 }

--- a/frontend/src/design-system/tokens/themes/dark.json
+++ b/frontend/src/design-system/tokens/themes/dark.json
@@ -8,5 +8,10 @@
   "--muted": "#1e293b",
   "--muted-foreground": "#94a3b8",
   "--destructive": "#dc2626",
-  "--destructive-foreground": "#f8fafc"
+  "--destructive-foreground": "#f8fafc",
+  "--accent": "#22c55e",
+  "--accent-foreground": "#052e16",
+  "--border": "#1e293b",
+  "--input": "#1e293b",
+  "--ring": "#3b82f6"
 }

--- a/frontend/src/design-system/tokens/themes/light.json
+++ b/frontend/src/design-system/tokens/themes/light.json
@@ -8,5 +8,10 @@
   "--muted": "#f1f5f9",
   "--muted-foreground": "#475569",
   "--destructive": "#b91c1c",
-  "--destructive-foreground": "#ffffff"
+  "--destructive-foreground": "#ffffff",
+  "--accent": "#22c55e",
+  "--accent-foreground": "#052e16",
+  "--border": "#e2e8f0",
+  "--input": "#ffffff",
+  "--ring": "#3b82f6"
 }

--- a/scripts/contrast-check.js
+++ b/scripts/contrast-check.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const THEMES_DIR = path.join(__dirname, '..', 'frontend', 'src', 'design-system', 'tokens', 'themes');
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const full = normalized.length === 3 ? normalized.split('').map(c => c + c).join('') : normalized;
+  const num = parseInt(full, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function luminance(r, g, b) {
+  const a = [r, g, b].map(v => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+}
+
+function contrast(hex1, hex2) {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const L1 = luminance(r1, g1, b1);
+  const L2 = luminance(r2, g2, b2);
+  const [hi, lo] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+function checkTheme(name, tokens) {
+  const pairs = [];
+  if (tokens['--background'] && tokens['--foreground']) {
+    pairs.push(['--background', '--foreground']);
+  }
+  Object.keys(tokens).forEach(key => {
+    if (key.endsWith('-foreground')) {
+      const base = key.replace('-foreground', '');
+      if (tokens[base]) {
+        pairs.push([base, key]);
+      }
+    }
+  });
+
+  const failures = [];
+  pairs.forEach(([bg, fg]) => {
+    const ratio = contrast(tokens[bg], tokens[fg]);
+    if (ratio < 4.5) {
+      failures.push(`${bg} vs ${fg} = ${ratio.toFixed(2)}`);
+    }
+  });
+
+  if (failures.length) {
+    throw new Error(`${name} theme contrast failures:\n${failures.join('\n')}`);
+  }
+}
+
+['light', 'dark'].forEach(name => {
+  const file = path.join(THEMES_DIR, `${name}.json`);
+  const raw = fs.readFileSync(file, 'utf8');
+  const tokens = JSON.parse(raw);
+  checkTheme(name, tokens);
+});
+
+console.log('All theme contrast ratios meet WCAG AA');


### PR DESCRIPTION
## Summary
- add contrast-check script to validate theme color pairs
- extend light and dark theme token files with accent and system colors
- implement toggleTheme helper for runtime CSS variable switching
- document theme creation and toggling

## Testing
- `npm --prefix frontend run lint -- src/design-system/theme-switcher.ts src/design-system/tokens/themes/light.json src/design-system/tokens/themes/dark.json`
- `npm --prefix frontend run format`
- `pre-commit run --files scripts/contrast-check.js frontend/src/design-system/theme-switcher.ts frontend/src/design-system/tokens/themes/light.json frontend/src/design-system/tokens/themes/dark.json docs/themes.md`
- `node scripts/contrast-check.js`
- `pytest` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_68979770b51c832798b997b404099c43