### PR TITLE
docs: add governance and contribution guides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,18 @@
 
 Describe the purpose of this pull request.
 
-## Checklist
-- [ ] Accessibility features considered
+## Testing
+- [ ] `pre-commit run --files <changed files>`
+- [ ] `python run_tests.py --quick`
+
+## Accessibility
+- [ ] Verified keyboard navigation and screen reader support
+- [ ] Meets WCAG AA guidelines
+
+## Documentation
 - [ ] Documentation updated or added
-- [ ] Tokens follow naming conventions
+- [ ] Links added to README and internal wiki
+
+## Token Usage
+- [ ] Existing design tokens reused where possible
+- [ ] New tokens documented with `fin-` prefix

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ FinVision is a comprehensive web-based financial modeling and analysis platform 
 - **Professional Reporting**: Generate publication-ready reports and presentations
 - **Role-Based Access Control**: Secure access with Admin/Analyst/Viewer roles
 
+## 📚 Documentation & Governance
+
+- [Contributing Guidelines](docs/contributing.md) – naming conventions, component guidelines, and review procedures (also on our [internal wiki](https://wiki.internal/FinVision/Contributing)).
+- [RFC Process](docs/rfc.md) – propose significant design system changes (also on our [internal wiki](https://wiki.internal/FinVision/RFC)).
+
 ## 🏗️ Architecture
 
 ### Frontend
@@ -303,7 +308,7 @@ See `/tasks/README.md` for detailed task breakdowns and progress tracking.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-Refer to the [Contributing Guidelines](docs/contributing.md) for token naming rules, component expectations, and review workflow. For major changes, start with the [RFC process](docs/rfc.md).
+Refer to the [Contributing Guidelines](docs/contributing.md) (also on our [internal wiki](https://wiki.internal/FinVision/Contributing)) for naming rules, component expectations, and review workflow. For major changes, start with the [RFC process](docs/rfc.md) (also on our [internal wiki](https://wiki.internal/FinVision/RFC)).
 
 ### Code Quality
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,19 +1,19 @@
 # Contributing Guidelines
 
-This guide explains how to contribute to the FinVision project and maintain consistency across the codebase.
+This guide explains how to contribute to the FinVision project and maintain consistency across the codebase. It is mirrored on the [internal wiki](https://wiki.internal/FinVision/Contributing) for easy reference.
 
-## Token Naming
-- Prefix design tokens with `fin-` to denote project scope.
-- Use lowercase, hyphen-separated names (e.g., `fin-primary-color`).
-- Group tokens by category (e.g., color, spacing) for clarity.
+## Naming Conventions
+- **Design tokens** use the `fin-` prefix and lowercase, hyphen-separated names (e.g., `fin-primary-color`).
+- **Components** are named in `PascalCase` and the filename should match the exported component.
+- **Branches** follow `type/short-description` (e.g., `feature/add-dashboard`).
 
 ## Component Guidelines
 - Build components using the defined design tokens.
 - Keep components small, focused, and reusable.
-- Document new components in the storybook or relevant docs.
+- Document new components in the Storybook or relevant docs.
 
-## Review Workflow
+## Review Procedures
 1. Create a branch for your change.
-2. Ensure pre-commit checks and tests pass.
+2. Run pre-commit checks and tests locally.
 3. Open a pull request and request review.
 4. Address feedback and obtain at least one approval before merging.

--- a/docs/rfc.md
+++ b/docs/rfc.md
@@ -1,15 +1,21 @@
 # Request for Comments (RFC) Process
 
-The RFC process is used for proposing substantial changes to the project.
+Use the RFC process to propose significant design system changes. This document is mirrored on the [internal wiki](https://wiki.internal/FinVision/RFC) for broader visibility.
 
-## Submission
-1. Create a new RFC document under `docs/rfcs/` or open an issue describing the proposal.
-2. Provide context, motivation, and a detailed technical plan.
+## When to Submit an RFC
+- Introducing or deprecating design tokens.
+- Adding new component patterns or altering foundational styles.
+- Major accessibility or theming shifts.
+
+## How to Submit
+1. Copy the RFC template under `docs/rfcs/` and fill out summary, motivation, detailed design, and alternatives.
+2. Open a pull request with the RFC document or create an issue linking to it.
+3. Share the draft with the `#design-system` channel for initial feedback.
 
 ## Review
-1. Share the RFC with maintainers and gather feedback.
-2. Iterate on the proposal until concerns are resolved.
+- Allow at least five business days for comments from maintainers and designers.
+- Incorporate feedback and clearly mark open questions.
 
 ## Approval
-- Obtain approval from at least two maintainers.
-- Merge the RFC and reference it in related pull requests.
+- Two maintainers, including one design lead, must approve.
+- Merge the RFC and reference the approved document in related pull requests.


### PR DESCRIPTION
## Summary
- document naming conventions, component standards, and review procedures
- define RFC workflow for design system proposals
- expand PR template with testing, accessibility, docs, and token checks
- link governance docs and internal wiki from README

## Testing
- `pre-commit run --files docs/contributing.md docs/rfc.md README.md .github/pull_request_template.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_689797673a6083278342c9449eb85d9c