### PR TITLE
feat(tokens): expand coverage with interaction and motion

### DIFF
--- a/config/style-dictionary.json
+++ b/config/style-dictionary.json
@@ -11,6 +11,27 @@
           "filter": {
             "attributes": { "category": "colors" }
           }
+        },
+        {
+          "destination": "borderWidth.css",
+          "format": "css/variables",
+          "filter": {
+            "attributes": { "category": "borderWidth" }
+          }
+        },
+        {
+          "destination": "typography.css",
+          "format": "css/variables",
+          "filter": {
+            "attributes": { "category": "typography" }
+          }
+        },
+        {
+          "destination": "motion.css",
+          "format": "css/variables",
+          "filter": {
+            "attributes": { "category": "motion" }
+          }
         }
       ]
     },

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -6,21 +6,26 @@ The design system exposes a consolidated set of tokens generated from `frontend/
 
 - `color.hover.primary` → `#2563eb`
 - `color.active.primary` → `#1d4ed8`
+- `color.hover.secondary` → `#475569`
+- `color.active.destructive` → `#b91c1c`
 
 ## Border Width
 
 - `border.width.sm` → `1px`
 - `border.width.md` → `2px`
+- `border.width.lg` → `4px`
 
 ## Typography Letter Spacing
 
 - `typography.letterSpacing.tight` → `-0.025em`
 - `typography.letterSpacing.wide` → `0.025em`
+- `typography.letterSpacing.tighter` → `-0.05em`
 
 ## Motion Easing
 
 - `motion.easing.in` → `cubic-bezier(0.4, 0, 1, 1)`
 - `motion.easing.inOut` → `cubic-bezier(0.4, 0, 0.2, 1)`
+- `motion.easing.out` → `cubic-bezier(0, 0, 0.2, 1)`
 
 These tokens can be consumed in components via the `getToken` helper:
 

--- a/frontend/src/design-system/components/Card.tsx
+++ b/frontend/src/design-system/components/Card.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../utils/cn';
+import { getToken } from '../tokens';
 
 const cardVariants = cva(
   [
     // Base styles
     'rounded-lg border bg-card text-card-foreground shadow-sm',
-    'transition-all duration-200 ease-in-out',
+    'transition-all duration-200',
   ],
   {
     variants: {
@@ -37,88 +38,59 @@ const cardVariants = cva(
   }
 );
 
-const cardHeaderVariants = cva(
-  [
-    'flex flex-col space-y-1.5',
-  ],
-  {
-    variants: {
-      padding: {
-        none: '',
-        sm: 'pb-3',
-        md: 'pb-4',
-        lg: 'pb-6',
-        xl: 'pb-8',
-      },
+const cardHeaderVariants = cva(['flex flex-col space-y-1.5'], {
+  variants: {
+    padding: {
+      none: '',
+      sm: 'pb-3',
+      md: 'pb-4',
+      lg: 'pb-6',
+      xl: 'pb-8',
     },
-    defaultVariants: {
-      padding: 'md',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    padding: 'md',
+  },
+});
 
-const cardTitleVariants = cva(
-  [
-    'text-2xl font-semibold leading-none tracking-tight',
-  ],
-  {
-    variants: {
-      size: {
-        sm: 'text-lg',
-        md: 'text-xl',
-        lg: 'text-2xl',
-        xl: 'text-3xl',
-      },
+const cardTitleVariants = cva(['text-2xl font-semibold leading-none'], {
+  variants: {
+    size: {
+      sm: 'text-lg',
+      md: 'text-xl',
+      lg: 'text-2xl',
+      xl: 'text-3xl',
     },
-    defaultVariants: {
-      size: 'lg',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
 
-const cardDescriptionVariants = cva(
-  [
-    'text-sm text-muted-foreground',
-  ],
-  {
-    variants: {
-    },
-    defaultVariants: {
-    },
-  }
-);
+const cardDescriptionVariants = cva(['text-sm text-muted-foreground'], {
+  variants: {},
+  defaultVariants: {},
+});
 
-const cardContentVariants = cva(
-  [
-    'pt-0',
-  ],
-  {
-    variants: {
-    },
-    defaultVariants: {
-    },
-  }
-);
+const cardContentVariants = cva(['pt-0'], {
+  variants: {},
+  defaultVariants: {},
+});
 
-const cardFooterVariants = cva(
-  [
-    'flex items-center pt-0',
-  ],
-  {
-    variants: {
-      padding: {
-        none: '',
-        sm: 'pt-3',
-        md: 'pt-4',
-        lg: 'pt-6',
-        xl: 'pt-8',
-      },
+const cardFooterVariants = cva(['flex items-center pt-0'], {
+  variants: {
+    padding: {
+      none: '',
+      sm: 'pt-3',
+      md: 'pt-4',
+      lg: 'pt-6',
+      xl: 'pt-8',
     },
-    defaultVariants: {
-      padding: 'md',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    padding: 'md',
+  },
+});
 
 export interface CardProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -149,6 +121,10 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={cn(cardVariants({ variant, padding, className }))}
+      style={{
+        borderWidth: getToken('borderWidth.sm'),
+        transitionTimingFunction: getToken('motion.easing.inOut'),
+      }}
       {...props}
     />
   )
@@ -171,21 +147,25 @@ const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
     <h3
       ref={ref}
       className={cn(cardTitleVariants({ size, className }))}
+      style={{
+        letterSpacing: getToken('typography.letterSpacing.tight'),
+      }}
       {...props}
     />
   )
 );
 CardTitle.displayName = 'CardTitle';
 
-const CardDescription = React.forwardRef<HTMLParagraphElement, CardDescriptionProps>(
-  ({ className, ...props }, ref) => (
-    <p
-      ref={ref}
-      className={cn(cardDescriptionVariants({ className }))}
-      {...props}
-    />
-  )
-);
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  CardDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn(cardDescriptionVariants({ className }))}
+    {...props}
+  />
+));
 CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(

--- a/tokens/borderWidth/base.json
+++ b/tokens/borderWidth/base.json
@@ -1,0 +1,16 @@
+{
+  "borderWidth": {
+    "none": {
+      "value": "0"
+    },
+    "sm": {
+      "value": "1px"
+    },
+    "md": {
+      "value": "2px"
+    },
+    "lg": {
+      "value": "4px"
+    }
+  }
+}

--- a/tokens/colors/base.json
+++ b/tokens/colors/base.json
@@ -175,6 +175,34 @@
         "value": "#020617"
       }
     },
+    "hover": {
+      "primary": {
+        "value": "#2563eb"
+      },
+      "secondary": {
+        "value": "#475569"
+      },
+      "accent": {
+        "value": "#16a34a"
+      },
+      "destructive": {
+        "value": "#dc2626"
+      }
+    },
+    "active": {
+      "primary": {
+        "value": "#1d4ed8"
+      },
+      "secondary": {
+        "value": "#334155"
+      },
+      "accent": {
+        "value": "#15803d"
+      },
+      "destructive": {
+        "value": "#b91c1c"
+      }
+    },
     "border": {
       "value": "#e2e8f0"
     },

--- a/tokens/motion/base.json
+++ b/tokens/motion/base.json
@@ -1,0 +1,15 @@
+{
+  "motion": {
+    "easing": {
+      "in": {
+        "value": "cubic-bezier(0.4, 0, 1, 1)"
+      },
+      "out": {
+        "value": "cubic-bezier(0, 0, 0.2, 1)"
+      },
+      "inOut": {
+        "value": "cubic-bezier(0.4, 0, 0.2, 1)"
+      }
+    }
+  }
+}

--- a/tokens/typography/base.json
+++ b/tokens/typography/base.json
@@ -83,6 +83,26 @@
       "loose": {
         "value": "2"
       }
+    },
+    "letterSpacing": {
+      "tighter": {
+        "value": "-0.05em"
+      },
+      "tight": {
+        "value": "-0.025em"
+      },
+      "normal": {
+        "value": "0"
+      },
+      "wide": {
+        "value": "0.025em"
+      },
+      "wider": {
+        "value": "0.05em"
+      },
+      "widest": {
+        "value": "0.1em"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add hover and active color tokens
- introduce border width, letter spacing, and easing primitives
- update Card component and build pipeline to consume new tokens

## Testing
- `npm run build:tokens`
- `pre-commit run --files tokens/colors/base.json tokens/typography/base.json tokens/borderWidth/base.json tokens/motion/base.json config/style-dictionary.json frontend/src/design-system/components/Card.tsx docs/tokens.md`
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6897975623d88327b987f644540d6957