### PR TITLE
Fix type checking issues in frontend tests and design tokens

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,7 +125,7 @@
     "@storybook/react-vite": "8.6.14",
     "@storybook/test-runner": "0.20.1",
     "@storybook/testing-library": "0.2.1",
-    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest-axe": "3.5.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -267,8 +267,8 @@ devDependencies:
     specifier: 0.2.1
     version: 0.2.1
   '@testing-library/jest-dom':
-    specifier: ^5.16.5
-    version: 5.17.0
+    specifier: ^6.5.0
+    version: 6.5.0
   '@testing-library/react':
     specifier: ^13.4.0
     version: 13.4.0(@types/react@18.3.23)(react-dom@18.3.1)(react@18.3.1)
@@ -4594,21 +4594,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@5.17.0:
-    resolution: {integrity: sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==}
-    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
-    dependencies:
-      '@adobe/css-tools': 4.4.3
-      '@babel/runtime': 7.28.2
-      '@types/testing-library__jest-dom': 5.14.9
-      aria-query: 5.3.2
-      chalk: 3.0.0
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.5.16
-      lodash: 4.17.21
-      redent: 3.0.0
-    dev: true
-
   /@testing-library/jest-dom@6.5.0:
     resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
@@ -4873,12 +4858,6 @@ packages:
   /@types/stylis@4.2.5:
     resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
     dev: false
-
-  /@types/testing-library__jest-dom@5.14.9:
-    resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
-    dependencies:
-      '@types/jest': 30.0.0
-    dev: true
 
   /@types/tough-cookie@4.0.5:
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}

--- a/frontend/src/components/Admin/__tests__/OverviewSection.test.tsx
+++ b/frontend/src/components/Admin/__tests__/OverviewSection.test.tsx
@@ -6,8 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import matchers from '@testing-library/jest-dom/matchers';
-expect.extend(matchers as any);
+import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { OverviewSection } from '../OverviewSection';
 import { useAdminStore } from '../../../stores/admin';

--- a/frontend/src/components/AdminDashboard/LogFilterForm.tsx
+++ b/frontend/src/components/AdminDashboard/LogFilterForm.tsx
@@ -9,9 +9,10 @@ import {
 } from '@/design-system/components/Select';
 import { Input } from '@/design-system/components/Input';
 import { DatePicker } from '@/design-system/components/DatePicker';
+import type { LogsState } from '@/stores/admin/types';
 
 interface LogFilterFormProps {
-  level: string;
+  level: LogsState['level'];
   limit: number;
   from: string;
   to: string;
@@ -19,7 +20,7 @@ interface LogFilterFormProps {
   skip: number;
   total: number;
   onChange: (updates: Partial<{
-    level: string;
+    level: LogsState['level'];
     limit: number;
     from: string;
     to: string;
@@ -46,7 +47,7 @@ const LogFilterForm: React.FC<LogFilterFormProps> = ({
 }) => {
   return (
     <div className="flex flex-wrap items-center gap-2 mb-4">
-      <Select value={level} onValueChange={v => onChange({ level: v, skip: 0 })}>
+        <Select value={level} onValueChange={v => onChange({ level: v as LogsState['level'], skip: 0 })}>
         <SelectTrigger className="w-[110px]">
           <SelectValue />
         </SelectTrigger>

--- a/frontend/src/components/AdminDashboard/__tests__/HealthTab.test.tsx
+++ b/frontend/src/components/AdminDashboard/__tests__/HealthTab.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import HealthTab from '../HealthTab';
 import { useAdminStore } from '@/stores/adminStore';
 

--- a/frontend/src/components/AdminDashboard/__tests__/LogsTab.filters.test.tsx
+++ b/frontend/src/components/AdminDashboard/__tests__/LogsTab.filters.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import LogsTab from '../LogsTab';
 import { useAdminStore } from '@/stores/adminStore';

--- a/frontend/src/components/AdminDashboard/__tests__/LogsTab.test.tsx
+++ b/frontend/src/components/AdminDashboard/__tests__/LogsTab.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import LogsTab from '../LogsTab';
 import { useAdminStore } from '@/stores/adminStore';

--- a/frontend/src/components/AdminDashboard/__tests__/OverviewTab.metrics-alerts.test.tsx
+++ b/frontend/src/components/AdminDashboard/__tests__/OverviewTab.metrics-alerts.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import OverviewTab from '../OverviewTab';
 import { useAdminStore } from '@/stores/adminStore';
 

--- a/frontend/src/design-system/tokens.ts
+++ b/frontend/src/design-system/tokens.ts
@@ -1,6 +1,6 @@
 import tokensJson from './tokens.json';
 
-export const tokens = tokensJson as const;
+export const tokens = tokensJson;
 
 
 export const cssVariables = {

--- a/frontend/src/design-system/utils/tokenHelpers.ts
+++ b/frontend/src/design-system/utils/tokenHelpers.ts
@@ -9,7 +9,6 @@ const designTokens = {
   fontSize: tokens.typography.fontSize as any,
   borderRadius: tokens.borderRadius,
   boxShadow: tokens.shadows,
-  transitionDuration: tokens.transitions,
   zIndex: tokens.zIndex,
 } as const;
 const colorTokens = { light: tokens.colors as any, dark: tokens.colors as any } as const;
@@ -21,7 +20,6 @@ export type FontSizeToken = keyof typeof designTokens.fontSize;
 export type BorderRadiusToken = keyof typeof designTokens.borderRadius;
 export type FontWeightToken = string;
 export type BoxShadowToken = keyof typeof designTokens.boxShadow;
-export type TransitionToken = keyof typeof designTokens.transitionDuration;
 export type ZIndexToken = keyof typeof designTokens.zIndex;
 export type AnimationCurveToken = keyof (typeof designTokens & { animationCurve: any })['animationCurve'];
 export type BreakpointToken = keyof (typeof designTokens & { breakpoints: any })['breakpoints'];
@@ -47,7 +45,7 @@ export const cssVar = (token: string): string => {
  */
 export const getSpacing = (size: SpacingToken, useVar = false): string => {
   if (useVar) {
-    return cssVar(`spacing-${size}`);
+    return cssVar(`spacing-${String(size)}`);
   }
   return designTokens.spacing[size];
 };
@@ -105,18 +103,6 @@ export const getBoxShadow = (size: BoxShadowToken, useVar = false): string => {
   return designTokens.boxShadow[size];
 };
 
-/**
- * Get transition duration
- * @param speed - The transition speed key
- * @param useVar - Whether to return CSS custom property
- * @returns The transition duration value
- */
-export const getTransition = (speed: TransitionToken, useVar = false): string => {
-  if (useVar) {
-    return cssVar(`duration-${speed}`);
-  }
-  return designTokens.transitionDuration[speed];
-};
 
 /**
  * Get z-index value

--- a/frontend/src/hooks/useDesignTokens.ts
+++ b/frontend/src/hooks/useDesignTokens.ts
@@ -81,15 +81,6 @@ export function useDesignTokens() {
   };
 
   /**
-   * Get transition duration value
-   * @param speed - The transition speed key
-   * @returns The transition duration value
-   */
-  const getTransitionDuration = (speed: keyof typeof tokens.transitions): string => {
-    return tokens.transitions[speed];
-  };
-
-  /**
    * Get z-index value
    * @param layer - The z-index layer key
    * @returns The z-index value
@@ -136,22 +127,20 @@ export function useDesignTokens() {
     getSpacing,
     getBorderRadius,
     getFontSize,
-    getFontWeight,
-    getBoxShadow,
-    getTransitionDuration,
-    getZIndex,
+      getFontWeight,
+      getBoxShadow,
+      getZIndex,
     getComponentToken,
 
     // Quick access to common values
-    spacing: tokens.spacing,
-    borderRadius: tokens.borderRadius,
-    fontSize: tokens.typography.fontSize as any,
-    fontWeight: {} as any,
-    boxShadow: tokens.shadows,
-    transitionDuration: tokens.transitions,
-    zIndex: tokens.zIndex as any,
-  };
-}
+      spacing: tokens.spacing,
+      borderRadius: tokens.borderRadius,
+      fontSize: tokens.typography.fontSize as any,
+      fontWeight: {} as any,
+      boxShadow: tokens.shadows,
+      zIndex: tokens.zIndex as any,
+    };
+  }
 
 /**
  * Type-safe design token selectors
@@ -162,7 +151,6 @@ export type BorderRadiusKey = keyof typeof tokens.borderRadius;
 export type FontSizeKey = keyof typeof tokens.typography.fontSize;
 export type FontWeightKey = string;
 export type BoxShadowKey = keyof typeof tokens.shadows;
-export type TransitionDurationKey = keyof typeof tokens.transitions;
 export type ZIndexKey = keyof typeof tokens.zIndex;
 export type ColorKey = keyof typeof tokens.colors;
 export type ComponentKey = string;

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -103,7 +103,7 @@ const AdminDashboard: React.FC = () => {
         envelope: true,
       });
       const env = resp as any;
-      setLogs((env.items as LogEntry[]) || []);
+      setLogEntries((env.items as LogEntry[]) || []);
       setLogsTotal(env.total || 0);
     },
     [

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 import React from 'react';
 


### PR DESCRIPTION
## Summary
- upgrade jest-dom and use Vitest-specific imports for matcher typings
- align log filter types with store definitions and cast select values
- drop unused transition token logic and correct log update setter

## Testing
- `pnpm type-check:ci`
- `pnpm test:minimal:ci` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689796662d5c83278ee55b24c276e4ed