### PR TITLE
refactor: remove unused dashboard layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,32 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { ThemeProvider } from "./components/ThemeProvider";
-import { AuthProvider } from "./contexts/AuthContext";
-import { Toaster } from "./components/ui/sonner";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom';
+import { ThemeProvider } from './components/ThemeProvider';
+import { AuthProvider } from './contexts/AuthContext';
+import { Toaster } from './components/ui/sonner';
 
 // Authentication Components
-import Login from "./pages/Login";
-import Register from "./pages/Register";
-import ForgotPasswordForm from "./components/auth/ForgotPasswordForm";
-import ResetPasswordForm from "./components/auth/ResetPasswordForm";
-import EmailVerification from "./components/auth/EmailVerification";
-import { 
-  AdminGuard, 
-  AnalystGuard, 
-  VerifiedUserGuard 
-} from "./components/auth/AuthGuard";
+import Login from './pages/Login';
+import Register from './pages/Register';
+import ForgotPasswordForm from './components/auth/ForgotPasswordForm';
+import ResetPasswordForm from './components/auth/ResetPasswordForm';
+import EmailVerification from './components/auth/EmailVerification';
+import {
+  AdminGuard,
+  AnalystGuard,
+  VerifiedUserGuard,
+} from './components/auth/AuthGuard';
 
 // Main Application Components
-import { DashboardLayout } from "./components/DashboardLayout";
-import Dashboard from "./pages/Dashboard";
-import Analytics from "./pages/Analytics";
-import FileUpload from "./pages/FileUpload";
-import Reports from "./pages/Reports";
-import ScenarioModeling from "./pages/ScenarioModeling";
+import Dashboard from './pages/Dashboard';
+import Analytics from './pages/Analytics';
+import FileUpload from './pages/FileUpload';
+import Reports from './pages/Reports';
+import ScenarioModeling from './pages/ScenarioModeling';
 
 // Error Boundary Component
 class ErrorBoundary extends React.Component<
@@ -69,13 +73,9 @@ class ErrorBoundary extends React.Component<
 }
 
 // Protected Layout Component
-const ProtectedLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <VerifiedUserGuard>
-    <DashboardLayout>
-      {children}
-    </DashboardLayout>
-  </VerifiedUserGuard>
-);
+const ProtectedLayout: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <VerifiedUserGuard>{children}</VerifiedUserGuard>;
 
 export default function App() {
   return (
@@ -88,79 +88,112 @@ export default function App() {
                 {/* Public Authentication Routes */}
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />
-                <Route path="/forgot-password" element={<ForgotPasswordForm />} />
+                <Route
+                  path="/forgot-password"
+                  element={<ForgotPasswordForm />}
+                />
                 <Route path="/reset-password" element={<ResetPasswordForm />} />
                 <Route path="/verify-email" element={<EmailVerification />} />
 
                 {/* Protected Application Routes */}
-                <Route path="/dashboard" element={
-                  <ProtectedLayout>
-                    <Dashboard />
-                  </ProtectedLayout>
-                } />
-
-                <Route path="/analytics" element={
-                  <ProtectedLayout>
-                    <Analytics />
-                  </ProtectedLayout>
-                } />
-
-                <Route path="/upload" element={
-                  <ProtectedLayout>
-                    <FileUpload />
-                  </ProtectedLayout>
-                } />
-
-                <Route path="/reports" element={
-                  <AnalystGuard>
+                <Route
+                  path="/dashboard"
+                  element={
                     <ProtectedLayout>
-                      <Reports />
+                      <Dashboard />
                     </ProtectedLayout>
-                  </AnalystGuard>
-                } />
+                  }
+                />
 
-                <Route path="/scenarios" element={
-                  <AnalystGuard>
+                <Route
+                  path="/analytics"
+                  element={
                     <ProtectedLayout>
-                      <ScenarioModeling />
+                      <Analytics />
                     </ProtectedLayout>
-                  </AnalystGuard>
-                } />
+                  }
+                />
+
+                <Route
+                  path="/upload"
+                  element={
+                    <ProtectedLayout>
+                      <FileUpload />
+                    </ProtectedLayout>
+                  }
+                />
+
+                <Route
+                  path="/reports"
+                  element={
+                    <AnalystGuard>
+                      <ProtectedLayout>
+                        <Reports />
+                      </ProtectedLayout>
+                    </AnalystGuard>
+                  }
+                />
+
+                <Route
+                  path="/scenarios"
+                  element={
+                    <AnalystGuard>
+                      <ProtectedLayout>
+                        <ScenarioModeling />
+                      </ProtectedLayout>
+                    </AnalystGuard>
+                  }
+                />
 
                 {/* Admin Only Routes - placeholder for future admin panel */}
-                <Route path="/admin/*" element={
-                  <AdminGuard>
-                    <ProtectedLayout>
-                      <div className="p-6">
-                        <h1 className="text-2xl font-bold mb-4">Admin Panel</h1>
-                        <p className="text-muted-foreground">
-                          Admin features coming soon...
-                        </p>
-                      </div>
-                    </ProtectedLayout>
-                  </AdminGuard>
-                } />
+                <Route
+                  path="/admin/*"
+                  element={
+                    <AdminGuard>
+                      <ProtectedLayout>
+                        <div className="p-6">
+                          <h1 className="text-2xl font-bold mb-4">
+                            Admin Panel
+                          </h1>
+                          <p className="text-muted-foreground">
+                            Admin features coming soon...
+                          </p>
+                        </div>
+                      </ProtectedLayout>
+                    </AdminGuard>
+                  }
+                />
 
                 {/* Default redirects */}
-                <Route path="/" element={<Navigate to="/dashboard" replace />} />
-                
+                <Route
+                  path="/"
+                  element={<Navigate to="/dashboard" replace />}
+                />
+
                 {/* 404 Fallback */}
-                <Route path="*" element={
-                  <div className="min-h-screen flex items-center justify-center bg-background">
-                    <div className="text-center space-y-4">
-                      <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
-                      <p className="text-xl text-muted-foreground">Page not found</p>
-                      <button
-                        onClick={() => window.history.back()}
-                        className="bg-primary text-primary-foreground px-6 py-2 rounded-md hover:bg-primary/90 transition-colors"
-                      >
-                        Go Back
-                      </button>
+                <Route
+                  path="*"
+                  element={
+                    <div className="min-h-screen flex items-center justify-center bg-background">
+                      <div className="text-center space-y-4">
+                        <h1 className="text-4xl font-bold text-muted-foreground">
+                          404
+                        </h1>
+                        <p className="text-xl text-muted-foreground">
+                          Page not found
+                        </p>
+                        <button
+                          onClick={() => window.history.back()}
+                          className="bg-primary text-primary-foreground px-6 py-2 rounded-md hover:bg-primary/90 transition-colors"
+                        >
+                          Go Back
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                } />
+                  }
+                />
               </Routes>
-              
+
               <Toaster />
             </div>
           </AuthProvider>

--- a/frontend/tsconfig.typecheck.json
+++ b/frontend/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/test",
+    "src/**/*.{spec,e2e}.ts",
+    "src/**/*.{spec,e2e}.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary
- add tsconfig for dedicated type checks excluding tests
- simplify ProtectedLayout to only wrap children with VerifiedUserGuard

## Testing
- `pnpm exec tsc --noEmit -p tsconfig.typecheck.json`
- `pre-commit run --files frontend/src/App.tsx frontend/tsconfig.typecheck.json` *(fails: Frontend ESLint exit 1)*
- `pnpm run test` *(fails: The package "@esbuild/linux-x64" could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68979d09b3bc83279e6bbb69c8baa3a2